### PR TITLE
Fix memory owner tracking

### DIFF
--- a/src/kernel.c
+++ b/src/kernel.c
@@ -180,6 +180,13 @@ int osCreateDeadlineTask(int deadline, TCB* task) {
 
     }
 
+    /*
+     * new_task_id is used during allocation to tag the stack memory with the
+     * correct owner.  Reset it here so subsequent allocations from running
+     * tasks are associated with the current_task_id instead of the last created
+     * task.
+     */
+    new_task_id = TID_NULL;
 
     return RTX_OK;
 }

--- a/src/memory.c
+++ b/src/memory.c
@@ -86,7 +86,14 @@ void* k_mem_alloc(unsigned int size) {
             }
 
             curr->allocated = 1;
-            curr->owner = new_task_id;
+            /*
+             * When creating a task the kernel sets new_task_id to the task's TID
+             * before calling k_mem_alloc() for its stack.  Once the kernel is
+             * running, dynamic allocations should be owned by the currently
+             * executing task.  Use new_task_id if it is valid, otherwise fall
+             * back to current_task_id.
+             */
+            curr->owner = (new_task_id != TID_NULL) ? new_task_id : current_task_id;
             last_alloc = curr;
             min_alloc_size = (last_alloc) ? ((min_alloc_size < aligned_size) ? min_alloc_size : aligned_size) : aligned_size;
 


### PR DESCRIPTION
## Summary
- fix memory allocator ownership so allocations during normal operation are owned by the current task
- reset `new_task_id` after creating a task

## Testing
- `make` *(fails: arm-none-eabi-gcc: No such file or directory)*