### PR TITLE
Fix thread pointer symbol usage

### DIFF
--- a/src/stm32f4xx_it.c
+++ b/src/stm32f4xx_it.c
@@ -32,7 +32,7 @@ extern int kernel_running;
 extern task_t current_TID;
 extern task_t next_TID;
 
-extern uint32_t* curr_thread_ptr;
+extern uint32_t* current_thread_ptr;
 extern uint32_t* next_thread_ptr;
 
 extern uint32_t g_system_time;

--- a/src/svc_handler.s
+++ b/src/svc_handler.s
@@ -30,7 +30,7 @@ handleOSYield:
 	STMDB R0!, {R4-R11}
 	MSR PSP, R0
 	BL updateSP
-	LDR R0, =curr_thread_ptr
+        LDR R0, =current_thread_ptr
 	LDR R1, [R0]
 	LDMIA R1!, {R4-R11}
 	MSR PSP, R1
@@ -39,7 +39,7 @@ handleOSYield:
 .global handleOSStart
 .thumb_func
 handleOSStart:
-	LDR R3, =curr_thread_ptr
+        LDR R3, =current_thread_ptr
 	LDR R2, [R3]
 	LDMIA R2!, {R4-R11}
 	MSR PSP, R2
@@ -50,7 +50,7 @@ handleOSStart:
 .thumb_func
 handleOSExit:
 	BL exitSP
-	LDR R0, =curr_thread_ptr
+        LDR R0, =current_thread_ptr
 	LDR R1, [R0]
 	LDMIA R1!, {R4-R11}
 	MSR PSP, R1


### PR DESCRIPTION
## Summary
- reference the correct thread pointer variable `current_thread_ptr` in interrupt and assembly files

## Testing
- `make all` *(fails: arm-none-eabi-gcc not found)*