### PR TITLE
Add system time and memory usage APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,11 @@ AymOS is a sophisticated real-time operating system (RTOS) designed for embedded
 - **Memory Protection**: Task-specific memory ownership and access control
 - **Stack Management**: Per-task stack allocation and management
 - **Memory Statistics**: External fragmentation monitoring and reporting
+- **Usage Monitoring**: Query total allocated heap memory at runtime
 
 ### System Features
 - **System Tick Timer**: Precise timing control with configurable system tick
+- **System Time API**: Applications can read the current tick count
 - **Interrupt Handling**: Comprehensive interrupt management system
 - **Task Synchronization**: Built-in mechanisms for task coordination
 - **Error Handling**: Robust error detection and handling mechanisms
@@ -77,12 +79,14 @@ osKernelStart();
 - `osTaskExit()`: Exit current task
 - `osGetTID()`: Get current task ID
 - `osSetPriority(uint8_t priority, task_t TID)`: Change task priority at runtime
+- `osGetSystemTime()`: Get elapsed system time in ticks
 
 ### Memory Management
 - `k_mem_init()`: Initialize memory management
 - `k_mem_alloc(unsigned int size)`: Allocate memory
 - `k_mem_dealloc(void* ptr)`: Deallocate memory
 - `k_mem_count_extfrag(unsigned int size)`: Count external fragmentation
+- `k_mem_get_usage()`: Get total allocated bytes
 
 
 ## Further Reading

--- a/docs/FUNCTIONALITY_OVERVIEW.md
+++ b/docs/FUNCTIONALITY_OVERVIEW.md
@@ -11,6 +11,7 @@ The kernel (`src/kernel.c`) is responsible for task management and scheduling. I
 - `osKernelStart` – starts executing tasks.
 - `osYield`, `osSleep`, and `osPeriodYield` – cause context switches through supervisor calls.
 - `osTaskExit` – remove a task and free its resources.
+- `osGetSystemTime` – read the current tick count maintained by the kernel.
 
 Context switching is performed in `src/svc_handler.s` using ARM SVC and PendSV exceptions.
 
@@ -24,6 +25,7 @@ Important API functions:
 - `k_mem_alloc` – allocates aligned memory, splitting blocks when needed.
 - `k_mem_dealloc` – frees a block and merges neighboring free regions.
 - `k_mem_count_extfrag` – counts how many free blocks are too small for a requested size.
+- `k_mem_get_usage` – returns the total number of bytes currently allocated.
 
 ## Startup and HAL
 
@@ -36,6 +38,7 @@ Several small test programs under `src/tests` demonstrate the kernel and memory 
 - `create_task_test.c` – creates tasks and monitors state transitions.
 - `allocation_timing_test.c` – measures memory allocation performance.
 - `periodic_test.c` – exercises periodic task behaviour.
+- `system_time_test.c` – prints the current system time and memory usage.
 
 Running `make` builds the tests using the ARM toolchain specified in the `Makefile`.
 

--- a/headers/k_mem.h
+++ b/headers/k_mem.h
@@ -5,5 +5,6 @@ int k_mem_init(void);
 void* k_mem_alloc(unsigned int size);
 int k_mem_dealloc(void* ptr);
 int k_mem_count_extfrag(unsigned int size);
+unsigned int k_mem_get_usage(void);
 
 #endif /* INC_K_MEM_H_ */

--- a/headers/k_task.h
+++ b/headers/k_task.h
@@ -38,5 +38,6 @@ void osPeriodYield(void);
 int osSetDeadline(int deadline, task_t TID);
 int osCreateDeadlineTask(int deadline, TCB* task);
 int osSetPriority(U8 priority, task_t TID);
+uint32_t osGetSystemTime(void);
 
 #endif /* INC_K_TASK_H_ */

--- a/src/kernel.c
+++ b/src/kernel.c
@@ -383,6 +383,10 @@ task_t osGetTID(void) {
     return current_task_id;
 }
 
+uint32_t osGetSystemTime(void) {
+    return system_time;
+}
+
 
 void SVC_Handler_Main(unsigned int *svc_args)
 {

--- a/src/memory.c
+++ b/src/memory.c
@@ -180,6 +180,22 @@ int k_mem_count_extfrag(unsigned int size) {
     return count;
 }
 
+unsigned int k_mem_get_usage(void) {
+    if (!mem_init_flag) {
+        return 0;
+    }
+
+    unsigned int used = 0;
+    MEM_BLOCK* curr = free_list;
+    while (curr != NULL) {
+        if (curr->allocated) {
+            used += curr->size;
+        }
+        curr = curr->next;
+    }
+    return used;
+}
+
 static uint32_t align_to_word(uint32_t size) {
     return (size + 3) & ~0x03;
 }

--- a/src/stm32f4xx_it.c
+++ b/src/stm32f4xx_it.c
@@ -35,7 +35,7 @@ extern task_t next_TID;
 extern uint32_t* current_thread_ptr;
 extern uint32_t* next_thread_ptr;
 
-extern uint32_t g_system_time;
+extern volatile uint32_t system_time;
 extern unsigned int svc_number;
 
 extern TCB task_list[];
@@ -163,7 +163,7 @@ void SysTick_Handler(void) {
         return;
     }
 
-    g_system_time++;
+    system_time++;
     context_switch_required = 0;
 
     updateTaskTimes();

--- a/src/tests/system_time_test.c
+++ b/src/tests/system_time_test.c
@@ -1,0 +1,30 @@
+#include "main.h"
+#include <stdio.h>
+#include "common.h"
+#include "k_task.h"
+#include "k_mem.h"
+
+void TickPrinter(void *arg) {
+    while (1) {
+        printf("time=%lu, mem=%u\r\n", osGetSystemTime(), k_mem_get_usage());
+        osSleep(1);
+    }
+}
+
+int main(void) {
+    HAL_Init();
+    SystemClock_Config();
+    MX_GPIO_Init();
+    MX_USART2_UART_Init();
+
+    osKernelInit();
+
+    TCB task;
+    task.stack_size = STACK_SIZE;
+    task.ptask = &TickPrinter;
+    osCreateTask(&task);
+
+    osKernelStart();
+
+    while (1);
+}


### PR DESCRIPTION
## Summary
- expose `osGetSystemTime()` for reading the current tick count
- add `k_mem_get_usage()` to report allocated heap bytes
- document the new features and add a simple test
- increment `system_time` inside the SysTick handler

## Testing
- `make clean`
- `make` *(fails: arm-none-eabi-gcc not found)*