### PR TITLE
[PR 1/7] Build reproducible NUCLEO-F401RE firmware

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+/.deps/
+/.tools/
+/build/
+/runs/

--- a/Makefile
+++ b/Makefile
@@ -1,101 +1,223 @@
-# AymOS Makefile
-PROJECT = aymos
+SHELL := /bin/bash
+export LC_ALL := C
+.DEFAULT_GOAL := firmware
 
-# Compiler settings
-PREFIX = arm-none-eabi-
-CC = $(PREFIX)gcc
-AS = $(PREFIX)as
-LD = $(PREFIX)ld
-OBJCOPY = $(PREFIX)objcopy
-OBJDUMP = $(PREFIX)objdump
-SIZE = $(PREFIX)size
+PROJECT := aymos
+BOARD ?= nucleo_f401re
+APP ?= boot
 
-# Target MCU
-MCU = cortex-m4
-FPU = -mfloat-abi=hard -mfpu=fpv4-sp-d16
+SUPPORTED_BOARDS := nucleo_f401re
+SUPPORTED_APPS := boot
 
-# Directories
-SRC_DIR = Src
-INC_DIR = Inc
-BUILD_DIR = build
-OBJ_DIR = $(BUILD_DIR)/obj
-BIN_DIR = $(BUILD_DIR)/bin
+ifeq ($(filter $(BOARD),$(SUPPORTED_BOARDS)),)
+$(error Unsupported BOARD '$(BOARD)'; supported boards: $(SUPPORTED_BOARDS))
+endif
+ifeq ($(filter $(APP),$(SUPPORTED_APPS)),)
+$(error Unsupported APP '$(APP)'; supported applications: $(SUPPORTED_APPS))
+endif
 
-# Source files
-SRCS = $(wildcard $(SRC_DIR)/*.c)
-ASMS = $(wildcard $(SRC_DIR)/*.s)
-OBJS = $(SRCS:$(SRC_DIR)/%.c=$(OBJ_DIR)/%.o) $(ASMS:$(SRC_DIR)/%.s=$(OBJ_DIR)/%.o)
+# PR 1 supports only the locked project-local toolchain. Reject external tool
+# selection before assigning these variables so command-line and environment
+# attempts cannot bypass tools/setup.sh --check. CC's built-in default is safe
+# to replace; all other non-default definitions are external overrides.
+override LOCKED_TOOL_VARIABLES := \
+	ARM_GNU_DIR \
+	CROSS_COMPILE \
+	CC \
+	OBJCOPY \
+	OBJDUMP \
+	READELF \
+	SIZE \
+	NM
+override EXTERNAL_TOOL_VARIABLES := $(strip $(foreach variable,$(LOCKED_TOOL_VARIABLES),\
+	$(if $(filter undefined default,$(origin $(variable))),,\
+		$(variable)[$(origin $(variable))])))
+ifneq ($(EXTERNAL_TOOL_VARIABLES),)
+$(error Locked tool variable override(s) rejected: $(EXTERNAL_TOOL_VARIABLES). Remove them and run 'make setup')
+endif
 
-# Include directories
-INCLUDES = -I$(INC_DIR)
+override ARM_GNU_DIR := .tools/arm-gnu-toolchain-14.3.rel1-x86_64-arm-none-eabi
+override CROSS_COMPILE := $(abspath $(ARM_GNU_DIR))/bin/arm-none-eabi-
+override CC := $(CROSS_COMPILE)gcc
+override OBJCOPY := $(CROSS_COMPILE)objcopy
+override OBJDUMP := $(CROSS_COMPILE)objdump
+override READELF := $(CROSS_COMPILE)readelf
+override SIZE := $(CROSS_COMPILE)size
+override NM := $(CROSS_COMPILE)nm
 
-# Compiler flags
-CFLAGS = -mcpu=$(MCU) $(FPU) -mthumb -Wall -g3 -O0 \
-         -ffunction-sections -fdata-sections \
-         -fno-strict-aliasing -fno-builtin -fshort-enums \
-         $(INCLUDES)
+CMSIS_CORE_DIR := .deps/stm32cube_f4_core/Drivers/CMSIS/Core/Include
+CMSIS_DEVICE_DIR := .deps/cmsis_device_f4
+HAL_DIR := .deps/stm32f4xx_hal_driver
 
-# Linker flags
-LDFLAGS = -mcpu=$(MCU) $(FPU) -mthumb -specs=nano.specs \
-          -TSTM32F407VGTx_FLASH.ld \
-          -Wl,-Map=$(BIN_DIR)/$(PROJECT).map \
-          -Wl,--gc-sections
+BUILD_DIR := build/$(BOARD)/$(APP)
+OBJ_DIR := $(BUILD_DIR)/obj
+ELF := $(BUILD_DIR)/$(PROJECT).elf
+BIN := $(BUILD_DIR)/$(PROJECT).bin
+MAP := $(BUILD_DIR)/$(PROJECT).map
+SIZE_REPORT := $(BUILD_DIR)/size.txt
+BUILD_METADATA := $(BUILD_DIR)/build-metadata.txt
+LINKER_SCRIPT := bsp/nucleo_f401re/stm32f401re.ld
 
-# Default target
-all: directories $(BIN_DIR)/$(PROJECT).elf $(BIN_DIR)/$(PROJECT).hex $(BIN_DIR)/$(PROJECT).bin
+PROJECT_C_SOURCES := \
+	apps/boot/main.c \
+	bsp/nucleo_f401re/src/board.c \
+	bsp/nucleo_f401re/src/interrupts.c \
+	bsp/nucleo_f401re/src/newlib_heap.c
 
-# Create necessary directories
-directories:
-	@mkdir -p $(OBJ_DIR) $(BIN_DIR)
+VENDOR_C_SOURCES := \
+	$(CMSIS_DEVICE_DIR)/Source/Templates/system_stm32f4xx.c \
+	$(HAL_DIR)/Src/stm32f4xx_hal.c \
+	$(HAL_DIR)/Src/stm32f4xx_hal_cortex.c \
+	$(HAL_DIR)/Src/stm32f4xx_hal_flash.c \
+	$(HAL_DIR)/Src/stm32f4xx_hal_gpio.c \
+	$(HAL_DIR)/Src/stm32f4xx_hal_rcc.c \
+	$(HAL_DIR)/Src/stm32f4xx_hal_uart.c
 
-# Compile C source files
-$(OBJ_DIR)/%.o: $(SRC_DIR)/%.c
-	@echo "Compiling $<"
-	@$(CC) $(CFLAGS) -c $< -o $@
+VENDOR_ASM_SOURCES := \
+	$(CMSIS_DEVICE_DIR)/Source/Templates/gcc/startup_stm32f401xe.s
 
-# Compile assembly files
-$(OBJ_DIR)/%.o: $(SRC_DIR)/%.s
-	@echo "Assembling $<"
-	@$(AS) -mcpu=$(MCU) -mthumb $< -o $@
+PROJECT_OBJECTS := $(addprefix $(OBJ_DIR)/,$(PROJECT_C_SOURCES:.c=.o))
+VENDOR_C_OBJECTS := $(addprefix $(OBJ_DIR)/,$(VENDOR_C_SOURCES:.c=.o))
+VENDOR_ASM_OBJECTS := $(addprefix $(OBJ_DIR)/,$(VENDOR_ASM_SOURCES:.s=.o))
+OBJECTS := $(VENDOR_ASM_OBJECTS) $(PROJECT_OBJECTS) $(VENDOR_C_OBJECTS)
+DEPENDENCY_FILES := $(OBJECTS:.o=.d)
 
-# Link object files
-$(BIN_DIR)/$(PROJECT).elf: $(OBJS)
-	@echo "Linking $@"
-	@$(CC) $(LDFLAGS) $(OBJS) -o $@
-	@$(SIZE) $@
+ARCH_FLAGS := -mcpu=cortex-m4 -mthumb -mfloat-abi=soft
+COMMON_CPPFLAGS := \
+	-DSTM32F401xE \
+	-DUSE_HAL_DRIVER \
+	-DUSER_VECT_TAB_ADDRESS \
+	-Ibsp/nucleo_f401re/include \
+	-isystem $(CMSIS_CORE_DIR) \
+	-isystem $(CMSIS_DEVICE_DIR)/Include \
+	-isystem $(HAL_DIR)/Inc \
+	-isystem $(HAL_DIR)/Inc/Legacy
+COMMON_CFLAGS := \
+	$(ARCH_FLAGS) \
+	-std=c11 \
+	-ffreestanding \
+	-ffunction-sections \
+	-fdata-sections \
+	-fno-builtin \
+	-fno-common \
+	-fno-strict-aliasing \
+	-g3 \
+	-Og
+PROJECT_WARNINGS := \
+	-Wall \
+	-Wextra \
+	-Werror \
+	-Wformat=2 \
+	-Wmissing-prototypes \
+	-Wpointer-arith \
+	-Wshadow \
+	-Wstrict-prototypes \
+	-Wundef
+VENDOR_WARNINGS := -Wall -Wextra
+DEPENDENCY_FLAGS := -MMD -MP
 
-# Create hex file
-$(BIN_DIR)/$(PROJECT).hex: $(BIN_DIR)/$(PROJECT).elf
-	@echo "Creating hex file"
-	@$(OBJCOPY) -O ihex $< $@
+LDFLAGS := \
+	$(ARCH_FLAGS) \
+	-nostartfiles \
+	--specs=nano.specs \
+	-T$(LINKER_SCRIPT) \
+	-Wl,--fatal-warnings \
+	-Wl,--gc-sections \
+	-Wl,--print-memory-usage \
+	-Wl,-Map,$(MAP) \
+	-Wl,--cref
 
-# Create binary file
-$(BIN_DIR)/$(PROJECT).bin: $(BIN_DIR)/$(PROJECT).elf
-	@echo "Creating binary file"
-	@$(OBJCOPY) -O binary $< $@
+.PHONY: firmware setup validate clean clean-build flash disassembly help check-setup FORCE
 
-# Clean build files
-clean:
-	@echo "Cleaning build files"
-	@rm -rf $(BUILD_DIR)
+firmware: check-setup $(ELF) $(BIN) $(SIZE_REPORT) $(BUILD_METADATA) validate
 
-# Flash the program (requires ST-Link)
-flash: $(BIN_DIR)/$(PROJECT).elf
-	@echo "Flashing program"
-	@st-flash write $(BIN_DIR)/$(PROJECT).bin 0x8000000
+setup:
+	@./tools/setup.sh
 
-# Debug information
-debug: $(BIN_DIR)/$(PROJECT).elf
-	@echo "Generating debug information"
-	@$(OBJDUMP) -S $< > $(BIN_DIR)/$(PROJECT).lst
+check-setup:
+	@./tools/setup.sh --check
 
-# Help information
+$(PROJECT_OBJECTS) $(VENDOR_C_OBJECTS) $(VENDOR_ASM_OBJECTS): | check-setup
+
+$(PROJECT_OBJECTS): $(OBJ_DIR)/%.o: %.c
+	@mkdir -p "$(dir $@)"
+	@printf 'CC(project) %s\n' "$<"
+	@$(CC) $(COMMON_CPPFLAGS) $(COMMON_CFLAGS) $(PROJECT_WARNINGS) \
+		$(DEPENDENCY_FLAGS) -c "$<" -o "$@"
+
+$(VENDOR_C_OBJECTS): $(OBJ_DIR)/%.o: %.c
+	@mkdir -p "$(dir $@)"
+	@printf 'CC(vendor)  %s\n' "$<"
+	@$(CC) $(COMMON_CPPFLAGS) $(COMMON_CFLAGS) $(VENDOR_WARNINGS) \
+		$(DEPENDENCY_FLAGS) -c "$<" -o "$@"
+
+$(VENDOR_ASM_OBJECTS): $(OBJ_DIR)/%.o: %.s
+	@mkdir -p "$(dir $@)"
+	@printf 'AS(vendor)  %s\n' "$<"
+	@$(CC) $(COMMON_CPPFLAGS) $(ARCH_FLAGS) -x assembler-with-cpp \
+		-MMD -MP -c "$<" -o "$@"
+
+$(ELF): $(OBJECTS) $(LINKER_SCRIPT)
+	@mkdir -p "$(dir $@)"
+	@printf 'LD           %s\n' "$@"
+	@$(CC) $(LDFLAGS) $(OBJECTS) -o "$@"
+
+$(MAP): $(ELF)
+	@test -f "$@"
+
+$(BIN): $(ELF)
+	@printf 'OBJCOPY      %s\n' "$@"
+	@$(OBJCOPY) -O binary "$<" "$@"
+
+$(SIZE_REPORT): $(ELF)
+	@$(SIZE) --format=berkeley "$<" | tee "$@"
+
+FORCE:
+
+$(BUILD_METADATA): FORCE $(ELF) tools/setup/dependencies.lock | check-setup
+	@{ \
+		printf 'project=%s\n' '$(PROJECT)'; \
+		printf 'board=%s\n' '$(BOARD)'; \
+		printf 'app=%s\n' '$(APP)'; \
+		printf 'git_commit=%s\n' "$$(git rev-parse HEAD)"; \
+		printf 'repository_clean=%s\n' "$$(test -z "$$(git status --porcelain)" && printf true || printf false)"; \
+		printf 'dependencies_verified=true\n'; \
+		printf 'dependencies_clean=true\n'; \
+		printf 'compiler=%s\n' "$$($(CC) -dumpfullversion)"; \
+		printf 'compiler_path=%s\n' '$(CC)'; \
+		printf 'architecture_flags=%s\n' '$(ARCH_FLAGS)'; \
+		printf 'stm32cube_f4=%s\n' "$$(git -C .deps/stm32cube_f4_core rev-parse HEAD)"; \
+		printf 'cmsis_device_f4=%s\n' "$$(git -C $(CMSIS_DEVICE_DIR) rev-parse HEAD)"; \
+		printf 'stm32f4xx_hal=%s\n' "$$(git -C $(HAL_DIR) rev-parse HEAD)"; \
+	} > "$@"
+
+validate: $(ELF) $(MAP) $(SIZE_REPORT) $(BUILD_METADATA)
+	@CROSS_COMPILE="$(CROSS_COMPILE)" \
+		./tools/validate_firmware.sh "$(ELF)" "$(MAP)" "$(BUILD_DIR)"
+
+disassembly: $(ELF)
+	@$(OBJDUMP) -d -S "$<" > "$(BUILD_DIR)/$(PROJECT).lst"
+	@printf '%s\n' "$(BUILD_DIR)/$(PROJECT).lst"
+
+flash: $(BIN)
+	@printf 'Physical NUCLEO-F401RE flashing is not validated in this environment.\n' >&2
+	@printf 'Install and explicitly invoke an ST-LINK tool on: %s\n' "$(BIN)" >&2
+	@exit 2
+
+clean-build:
+	@rm -rf -- "$(BUILD_DIR)"
+
+clean: clean-build
+
 help:
-	@echo "Available targets:"
-	@echo "  all      - Build the project (default)"
-	@echo "  clean    - Remove all build files"
-	@echo "  flash    - Flash the program to the device"
-	@echo "  debug    - Generate debug information"
-	@echo "  help     - Show this help message"
+	@printf '%s\n' \
+		'make setup        Install and verify pinned project-local dependencies' \
+		'make firmware     Build and validate the F401RE boot firmware (default)' \
+		'make validate     Re-run ELF, map, ABI, and memory validation' \
+		'make disassembly  Generate an annotated disassembly' \
+		'make clean        Remove this board/application build directory' \
+		'make flash        Build, then stop with the unvalidated hardware notice' \
+		'' \
+		'Selection: BOARD=nucleo_f401re APP=boot (the only PR 1 choices)'
 
-.PHONY: all clean flash debug help directories 
+-include $(DEPENDENCY_FILES)

--- a/README.md
+++ b/README.md
@@ -1,92 +1,134 @@
-# AymOS - A Lightweight Real-Time Operating System
+# AymOS Real-Time Systems Lab
 
-AymOS is a sophisticated real-time operating system (RTOS) designed for embedded systems, specifically targeting ARM Cortex-M4 microcontrollers. Built from the ground up in C, it provides a robust foundation for real-time applications with a focus on efficiency, reliability, and precise timing control.
+AymOS is becoming a small, inspectable Cortex-M4 real-time systems lab. The
+current verified slice builds a board-targeted boot image reproducibly. The EDF
+kernel source is retained for the next architecture/lifecycle PR, but is not
+linked into the PR 1 boot application and is not yet claimed to execute safely.
 
-## Key Features
+The canonical target is the STM32F401RE on a NUCLEO-F401RE board:
 
-### Real-Time Task Management
-- **Earliest Deadline First (EDF) Scheduling**: Implements a dynamic priority scheduling algorithm that ensures tasks meet their timing requirements
-- **Priority Support**: Tasks have an explicit priority used to break deadline ties and can be changed at runtime
-- **Task States**: Comprehensive task state management (READY, RUNNING, SLEEPING, DORMANT)
-- **Deadline-Based Execution**: Tasks can be created with specific deadlines and time remaining parameters
-- **Context Switching**: Efficient context switching mechanism using ARM's SVC and PendSV exceptions
-- **Task Information**: Detailed task information retrieval and management capabilities
+- ARM Cortex-M4 / Thumb-2;
+- 512 KiB flash at `0x08000000`;
+- 96 KiB SRAM at `0x20000000`;
+- USART2 on PA2/PA3 at 115200 8N1;
+- user LED on PA5; and
+- software floating-point ABI until floating-point context preservation is
+  implemented and tested.
 
-### Memory Management
-- **Dynamic Memory Allocation**: Custom memory allocator with efficient block management
-- **Memory Fragmentation Handling**: Built-in memory coalescing to prevent fragmentation
-- **Memory Protection**: Task-specific memory ownership and access control
-- **Stack Management**: Per-task stack allocation and management
-- **Memory Statistics**: External fragmentation monitoring and reporting
+## Implemented and tested
 
-### System Features
-- **System Tick Timer**: Precise timing control with configurable system tick
-- **Interrupt Handling**: Comprehensive interrupt management system
-- **Task Synchronization**: Built-in mechanisms for task coordination
-- **Error Handling**: Robust error detection and handling mechanisms
-- **Debug Support**: Integrated debugging capabilities
+- Rootless, project-local Arm GNU Toolchain 14.3.rel1 setup on Linux x86_64.
+- Immutable STM32CubeF4 v1.28.3-compatible CMSIS Core, F401 device, and HAL
+  sources with commit and cleanliness validation.
+- Explicit source manifests; no source-directory wildcard discovery.
+- F401xE startup/vector assembly and a reviewed F401RE linker memory map.
+- `SystemInit` sets VTOR to flash before `HAL_Init` enables SysTick.
+- HAL-only SysTick, 84 MHz clock setup, GPIO, and polling USART2 boot output.
+- A linker-owned, eight-byte-aligned AymOS heap region, an empty newlib heap,
+  and a separate 4 KiB MSP reservation.
+- ELF, binary, map, size, build metadata, attributes, symbols, vector bytes, and
+  memory-range validation.
 
-## Technical Specifications
+The build has been validated locally. Renode boot and CI are PR 2 scope, so the
+UART banner has not yet been observed in an emulator in this branch.
 
-- **Architecture**: ARM Cortex-M4
-- **Programming Language**: C
-- **Memory Model**: Protected memory space with task isolation
-- **Scheduling Algorithm**: EDF (Earliest Deadline First)
-- **Interrupt Priority Levels**: Configurable interrupt priorities for system services
+## Build
 
-## Getting Started
+The supported PR 1 host is Linux x86_64. Required bootstrap commands are
+`awk`, `bash`, Git 2.25+, curl 7.61+, `make`, `file`, `grep`, `od`, `sha256sum`,
+`stat`, `tar`, and `xz`. Root access and a global ARM compiler are not used.
 
-### Prerequisites
-- ARM Cortex-M4 compatible development board
-- ARM GCC toolchain
-- STM32CubeIDE or similar development environment
-
-### Building the Project
-```bash
-# Clone the repository
-git clone https://github.com/{username}/aymos.git
-
-# Build the project
-make
+```sh
+make setup
+make firmware
 ```
 
-### Basic Usage
-```c
-// Initialize the kernel
-osKernelInit();
+`make setup` downloads a 149,789,432-byte Arm archive, checks its locked
+SHA-256 before extraction, and obtains only the locked STM32 source components
+under `.tools/` and `.deps/`. It is safe to rerun and rejects locally modified
+dependencies rather than overwriting them.
 
-// Create a task with deadline
-TCB myTask;
-myTask.ptask = myTaskFunction;
-myTask.stack_size = STACK_SIZE;
-osCreateDeadlineTask(deadline_ms, &myTask);
+Every build first runs `tools/setup.sh --check`, an offline/read-only integrity
+gate. Compilation cannot start until all consumed tool hashes, dependency
+commits, clean states, files, and licenses pass.
 
-// Start the kernel
-osKernelStart();
+The only current selection is explicit:
+
+```sh
+make firmware BOARD=nucleo_f401re APP=boot
 ```
 
-## API Reference
+Unknown board/application names fail instead of silently changing the image.
+See [docs/BUILDING.md](docs/BUILDING.md) for dependency provenance, artifact
+paths, validation details, and clean-build instructions.
 
-This repository includes a detailed [API reference](docs/API_REFERENCE.md) that
-describes every public function. Below is a short overview of the most commonly
-used calls.
+Key outputs are under `build/nucleo_f401re/boot/`:
 
-### Task Management
-- `osKernelInit()` – initialise the kernel
-- `osKernelStart()` – start executing tasks
-- `osCreateDeadlineTask(int deadline, TCB* task)` – create a task with a specific deadline
-- `osYield()` – yield CPU to the next ready task
-- `osSleep(int timeInMs)` – put the current task to sleep
-- `osTaskExit()` – terminate the current task
-- `osGetTID()` – obtain the current task ID
-- `osSetPriority(uint8_t priority, task_t TID)` – change a task's priority
+```text
+aymos.elf
+aymos.bin
+aymos.map
+size.txt
+build-metadata.txt
+file.txt
+readelf-header.txt
+readelf-attributes.txt
+readelf-sections.txt
+readelf-program-headers.txt
+symbols.txt
+vector-table.bin
+```
 
-### Memory Management
-- `k_mem_init()` – initialise memory management
-- `k_mem_alloc(unsigned int size)` – allocate memory
-- `k_mem_dealloc(void* ptr)` – free allocated memory
-- `k_mem_count_extfrag(unsigned int size)` – count external fragmentation
+Useful commands:
 
+```sh
+make validate
+make disassembly
+make clean
+make help
+```
 
-## Further Reading
-See [docs/FUNCTIONALITY_OVERVIEW.md](docs/FUNCTIONALITY_OVERVIEW.md) for a more detailed description of how each module operates.
+`make flash` deliberately stops after building and prints an unvalidated
+hardware notice. It does not guess which probe/programmer the user has.
+
+## Implemented but experimental
+
+The legacy source tree contains:
+
+- a 16-slot task table with an EDF-like scan and priority tie breaker;
+- Cortex-M SVC/PendSV assembly intended to save and restore R4-R11 on PSP; and
+- a linked-list allocator with splitting, task-owner metadata, and coalescing.
+
+These components are educational prototypes. They currently have known task
+state, frame, timing-model, interrupt, alignment, and allocator issues recorded
+in [the implementation plan](docs/IMPLEMENTATION_PLAN.md). Allocator ownership
+metadata is not hardware memory protection or task isolation.
+
+The API inventory in [docs/API_REFERENCE.md](docs/API_REFERENCE.md) describes
+the legacy source surface, not a verified PR 1 runtime contract.
+
+## Planned campaign
+
+The reviewed sequence is:
+
+1. reproducible F401RE build (this slice);
+2. Renode boot harness and emulator tests;
+3. task lifecycle and Cortex-M context-switch correctness;
+4. explicit timing semantics and deterministic EDF tests;
+5. allocator hardening;
+6. bounded structured kernel tracing; and
+7. the Deadline Lab workload and standalone scheduling timeline.
+
+The complete gates, review requirements, and deferred scope are in
+[docs/IMPLEMENTATION_PLAN.md](docs/IMPLEMENTATION_PLAN.md).
+
+Message queues, synchronization primitives, networking, filesystems, USB,
+process isolation, POSIX compatibility, and a general shell are not implemented
+and are explicitly outside this campaign.
+
+## Hardware and timing status
+
+No physical NUCLEO-F401RE was available for this build slice. Board flashing and
+serial output therefore remain unvalidated. Future Renode results will prove
+functional event ordering in the model; they will not prove physical interrupt
+latency, worst-case execution time, or hard real-time guarantees.

--- a/apps/boot/main.c
+++ b/apps/boot/main.c
@@ -1,0 +1,20 @@
+#include "board.h"
+
+#include "stm32f4xx.h"
+
+int main(void)
+{
+    static const char banner[] = "AYMOS BOOT F401RE\r\n";
+
+    if (board_init() != HAL_OK) {
+        board_panic();
+    }
+
+    if (board_uart_write(banner, sizeof(banner) - 1U) != HAL_OK) {
+        board_panic();
+    }
+
+    for (;;) {
+        __WFI();
+    }
+}

--- a/bsp/nucleo_f401re/include/board.h
+++ b/bsp/nucleo_f401re/include/board.h
@@ -1,0 +1,12 @@
+#ifndef AYMOS_NUCLEO_F401RE_BOARD_H
+#define AYMOS_NUCLEO_F401RE_BOARD_H
+
+#include "stm32f4xx_hal.h"
+
+#include <stddef.h>
+
+HAL_StatusTypeDef board_init(void);
+HAL_StatusTypeDef board_uart_write(const char *data, size_t length);
+void board_panic(void) __attribute__((noreturn));
+
+#endif

--- a/bsp/nucleo_f401re/include/stm32f4xx_hal_conf.h
+++ b/bsp/nucleo_f401re/include/stm32f4xx_hal_conf.h
@@ -1,0 +1,94 @@
+#ifndef STM32F4XX_HAL_CONF_H
+#define STM32F4XX_HAL_CONF_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define HAL_MODULE_ENABLED
+#define HAL_CORTEX_MODULE_ENABLED
+#define HAL_DMA_MODULE_ENABLED
+#define HAL_FLASH_MODULE_ENABLED
+#define HAL_GPIO_MODULE_ENABLED
+#define HAL_PWR_MODULE_ENABLED
+#define HAL_RCC_MODULE_ENABLED
+#define HAL_UART_MODULE_ENABLED
+
+#ifndef HSE_VALUE
+#define HSE_VALUE 8000000U
+#endif
+
+#ifndef HSE_STARTUP_TIMEOUT
+#define HSE_STARTUP_TIMEOUT 100U
+#endif
+
+#ifndef HSI_VALUE
+#define HSI_VALUE 16000000U
+#endif
+
+#ifndef LSI_VALUE
+#define LSI_VALUE 32000U
+#endif
+
+#ifndef LSE_VALUE
+#define LSE_VALUE 32768U
+#endif
+
+#ifndef LSE_STARTUP_TIMEOUT
+#define LSE_STARTUP_TIMEOUT 5000U
+#endif
+
+#ifndef EXTERNAL_CLOCK_VALUE
+#define EXTERNAL_CLOCK_VALUE 12288000U
+#endif
+
+#define VDD_VALUE 3300U
+#define TICK_INT_PRIORITY 0x0FU
+#define USE_RTOS 0U
+#define PREFETCH_ENABLE 1U
+#define INSTRUCTION_CACHE_ENABLE 1U
+#define DATA_CACHE_ENABLE 1U
+
+#define USE_HAL_UART_REGISTER_CALLBACKS 0U
+
+#ifdef USE_FULL_ASSERT
+void assert_failed(uint8_t *file, uint32_t line);
+#define assert_param(expression) \
+    ((expression) ? (void)0U : assert_failed((uint8_t *)__FILE__, __LINE__))
+#else
+#define assert_param(expression) ((void)0U)
+#endif
+
+#ifdef HAL_RCC_MODULE_ENABLED
+#include "stm32f4xx_hal_rcc.h"
+#endif
+
+#ifdef HAL_GPIO_MODULE_ENABLED
+#include "stm32f4xx_hal_gpio.h"
+#endif
+
+#ifdef HAL_CORTEX_MODULE_ENABLED
+#include "stm32f4xx_hal_cortex.h"
+#endif
+
+#ifdef HAL_DMA_MODULE_ENABLED
+#include "stm32f4xx_hal_dma.h"
+#endif
+
+#ifdef HAL_FLASH_MODULE_ENABLED
+#include "stm32f4xx_hal_flash.h"
+#endif
+
+#ifdef HAL_PWR_MODULE_ENABLED
+#include "stm32f4xx_hal_pwr.h"
+#endif
+
+#ifdef HAL_UART_MODULE_ENABLED
+#include "stm32f4xx_hal_uart.h"
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/bsp/nucleo_f401re/src/board.c
+++ b/bsp/nucleo_f401re/src/board.c
@@ -1,0 +1,150 @@
+#include "board.h"
+
+#include "stm32f4xx.h"
+
+#include <stdint.h>
+
+enum {
+    AYMOS_UART_TIMEOUT_MS = 1000U,
+    AYMOS_UART_CHUNK_MAX = UINT16_MAX
+};
+
+static UART_HandleTypeDef uart2;
+
+static HAL_StatusTypeDef configure_clock(void);
+static HAL_StatusTypeDef configure_gpio(void);
+static HAL_StatusTypeDef configure_uart(void);
+
+HAL_StatusTypeDef board_init(void)
+{
+    if (HAL_Init() != HAL_OK) {
+        return HAL_ERROR;
+    }
+
+    if (configure_clock() != HAL_OK) {
+        return HAL_ERROR;
+    }
+    if (configure_gpio() != HAL_OK) {
+        return HAL_ERROR;
+    }
+    return configure_uart();
+}
+
+HAL_StatusTypeDef board_uart_write(const char *data, size_t length)
+{
+    size_t offset = 0U;
+
+    if ((data == NULL) && (length != 0U)) {
+        return HAL_ERROR;
+    }
+
+    while (offset < length) {
+        const size_t remaining = length - offset;
+        const uint16_t chunk = (remaining > AYMOS_UART_CHUNK_MAX)
+                                   ? UINT16_MAX
+                                   : (uint16_t)remaining;
+        HAL_StatusTypeDef status = HAL_UART_Transmit(
+            &uart2, (uint8_t *)(data + offset), chunk, AYMOS_UART_TIMEOUT_MS);
+
+        if (status != HAL_OK) {
+            return status;
+        }
+        offset += chunk;
+    }
+
+    return HAL_OK;
+}
+
+void board_panic(void)
+{
+    __disable_irq();
+    for (;;) {
+        __NOP();
+    }
+}
+
+void HAL_MspInit(void)
+{
+    __HAL_RCC_SYSCFG_CLK_ENABLE();
+    __HAL_RCC_PWR_CLK_ENABLE();
+    HAL_NVIC_SetPriorityGrouping(NVIC_PRIORITYGROUP_4);
+}
+
+void HAL_UART_MspInit(UART_HandleTypeDef *handle)
+{
+    GPIO_InitTypeDef gpio = {0};
+
+    if (handle->Instance != USART2) {
+        return;
+    }
+
+    __HAL_RCC_USART2_CLK_ENABLE();
+    __HAL_RCC_GPIOA_CLK_ENABLE();
+
+    gpio.Pin = GPIO_PIN_2 | GPIO_PIN_3;
+    gpio.Mode = GPIO_MODE_AF_PP;
+    gpio.Pull = GPIO_NOPULL;
+    gpio.Speed = GPIO_SPEED_FREQ_VERY_HIGH;
+    gpio.Alternate = GPIO_AF7_USART2;
+    HAL_GPIO_Init(GPIOA, &gpio);
+}
+
+static HAL_StatusTypeDef configure_clock(void)
+{
+    RCC_OscInitTypeDef oscillator = {0};
+    RCC_ClkInitTypeDef clocks = {0};
+
+    __HAL_RCC_PWR_CLK_ENABLE();
+    __HAL_PWR_VOLTAGESCALING_CONFIG(PWR_REGULATOR_VOLTAGE_SCALE2);
+
+    oscillator.OscillatorType = RCC_OSCILLATORTYPE_HSI;
+    oscillator.HSIState = RCC_HSI_ON;
+    oscillator.HSICalibrationValue = RCC_HSICALIBRATION_DEFAULT;
+    oscillator.PLL.PLLState = RCC_PLL_ON;
+    oscillator.PLL.PLLSource = RCC_PLLSOURCE_HSI;
+    oscillator.PLL.PLLM = 16U;
+    oscillator.PLL.PLLN = 336U;
+    oscillator.PLL.PLLP = RCC_PLLP_DIV4;
+    oscillator.PLL.PLLQ = 7U;
+    if (HAL_RCC_OscConfig(&oscillator) != HAL_OK) {
+        return HAL_ERROR;
+    }
+
+    clocks.ClockType = RCC_CLOCKTYPE_HCLK | RCC_CLOCKTYPE_SYSCLK |
+                       RCC_CLOCKTYPE_PCLK1 | RCC_CLOCKTYPE_PCLK2;
+    clocks.SYSCLKSource = RCC_SYSCLKSOURCE_PLLCLK;
+    clocks.AHBCLKDivider = RCC_SYSCLK_DIV1;
+    clocks.APB1CLKDivider = RCC_HCLK_DIV2;
+    clocks.APB2CLKDivider = RCC_HCLK_DIV1;
+
+    return HAL_RCC_ClockConfig(&clocks, FLASH_LATENCY_2);
+}
+
+static HAL_StatusTypeDef configure_gpio(void)
+{
+    GPIO_InitTypeDef gpio = {0};
+
+    __HAL_RCC_GPIOA_CLK_ENABLE();
+
+    HAL_GPIO_WritePin(GPIOA, GPIO_PIN_5, GPIO_PIN_RESET);
+    gpio.Pin = GPIO_PIN_5;
+    gpio.Mode = GPIO_MODE_OUTPUT_PP;
+    gpio.Pull = GPIO_NOPULL;
+    gpio.Speed = GPIO_SPEED_FREQ_LOW;
+    HAL_GPIO_Init(GPIOA, &gpio);
+
+    return HAL_OK;
+}
+
+static HAL_StatusTypeDef configure_uart(void)
+{
+    uart2.Instance = USART2;
+    uart2.Init.BaudRate = 115200U;
+    uart2.Init.WordLength = UART_WORDLENGTH_8B;
+    uart2.Init.StopBits = UART_STOPBITS_1;
+    uart2.Init.Parity = UART_PARITY_NONE;
+    uart2.Init.Mode = UART_MODE_TX_RX;
+    uart2.Init.HwFlowCtl = UART_HWCONTROL_NONE;
+    uart2.Init.OverSampling = UART_OVERSAMPLING_16;
+    return HAL_UART_Init(&uart2);
+}

--- a/bsp/nucleo_f401re/src/interrupts.c
+++ b/bsp/nucleo_f401re/src/interrupts.c
@@ -1,0 +1,53 @@
+#include "stm32f4xx_hal.h"
+
+void NMI_Handler(void);
+void HardFault_Handler(void);
+void MemManage_Handler(void);
+void BusFault_Handler(void);
+void UsageFault_Handler(void);
+void DebugMon_Handler(void);
+void SysTick_Handler(void);
+
+static void fault_stop(void) __attribute__((noreturn));
+
+void NMI_Handler(void)
+{
+    fault_stop();
+}
+
+void HardFault_Handler(void)
+{
+    fault_stop();
+}
+
+void MemManage_Handler(void)
+{
+    fault_stop();
+}
+
+void BusFault_Handler(void)
+{
+    fault_stop();
+}
+
+void UsageFault_Handler(void)
+{
+    fault_stop();
+}
+
+void DebugMon_Handler(void)
+{
+}
+
+void SysTick_Handler(void)
+{
+    HAL_IncTick();
+}
+
+static void fault_stop(void)
+{
+    __disable_irq();
+    for (;;) {
+        __NOP();
+    }
+}

--- a/bsp/nucleo_f401re/src/newlib_heap.c
+++ b/bsp/nucleo_f401re/src/newlib_heap.c
@@ -1,0 +1,21 @@
+#include <errno.h>
+#include <stddef.h>
+
+void *_sbrk(ptrdiff_t increment);
+void _init(void);
+void _fini(void);
+
+void *_sbrk(ptrdiff_t increment)
+{
+    (void)increment;
+    errno = ENOMEM;
+    return (void *)-1;
+}
+
+void _init(void)
+{
+}
+
+void _fini(void)
+{
+}

--- a/bsp/nucleo_f401re/stm32f401re.ld
+++ b/bsp/nucleo_f401re/stm32f401re.ld
@@ -1,0 +1,134 @@
+ENTRY(Reset_Handler)
+EXTERN(_sbrk)
+
+MEMORY
+{
+    FLASH (rx)  : ORIGIN = 0x08000000, LENGTH = 512K
+    RAM   (xrw) : ORIGIN = 0x20000000, LENGTH = 96K
+}
+
+_Min_Stack_Size = 0x1000;
+_estack = ORIGIN(RAM) + LENGTH(RAM);
+
+SECTIONS
+{
+    .isr_vector ORIGIN(FLASH) : ALIGN(0x200)
+    {
+        __vector_table_start__ = .;
+        KEEP(*(.isr_vector))
+        __vector_table_end__ = .;
+    } > FLASH
+
+    .text :
+    {
+        . = ALIGN(4);
+        *(.text)
+        *(.text*)
+        *(.glue_7)
+        *(.glue_7t)
+        *(.eh_frame)
+        KEEP(*(.init))
+        KEEP(*(.fini))
+        . = ALIGN(4);
+        _etext = .;
+    } > FLASH
+
+    .rodata :
+    {
+        . = ALIGN(4);
+        *(.rodata)
+        *(.rodata*)
+        . = ALIGN(4);
+    } > FLASH
+
+    .ARM.extab :
+    {
+        *(.ARM.extab* .gnu.linkonce.armextab.*)
+    } > FLASH
+
+    .ARM.exidx :
+    {
+        __exidx_start = .;
+        *(.ARM.exidx*)
+        __exidx_end = .;
+    } > FLASH
+
+    .preinit_array :
+    {
+        PROVIDE_HIDDEN(__preinit_array_start = .);
+        KEEP(*(.preinit_array*))
+        PROVIDE_HIDDEN(__preinit_array_end = .);
+    } > FLASH
+
+    .init_array :
+    {
+        PROVIDE_HIDDEN(__init_array_start = .);
+        KEEP(*(SORT(.init_array.*)))
+        KEEP(*(.init_array*))
+        PROVIDE_HIDDEN(__init_array_end = .);
+    } > FLASH
+
+    .fini_array :
+    {
+        PROVIDE_HIDDEN(__fini_array_start = .);
+        KEEP(*(SORT(.fini_array.*)))
+        KEEP(*(.fini_array*))
+        PROVIDE_HIDDEN(__fini_array_end = .);
+    } > FLASH
+
+    _sidata = LOADADDR(.data);
+
+    .data :
+    {
+        . = ALIGN(4);
+        _sdata = .;
+        *(.data)
+        *(.data*)
+        . = ALIGN(4);
+        _edata = .;
+    } > RAM AT > FLASH
+
+    .bss (NOLOAD) :
+    {
+        . = ALIGN(8);
+        _sbss = .;
+        __bss_start__ = .;
+        *(.bss)
+        *(.bss*)
+        *(COMMON)
+        . = ALIGN(8);
+        _ebss = .;
+        __bss_end__ = .;
+    } > RAM
+
+    .aymos_heap (NOLOAD) :
+    {
+        . = ALIGN(8);
+        __aymos_heap_start__ = .;
+        . = ORIGIN(RAM) + LENGTH(RAM) - _Min_Stack_Size;
+        __aymos_heap_end__ = .;
+    } > RAM
+
+    __newlib_heap_start__ = __aymos_heap_start__;
+    __newlib_heap_end__ = __aymos_heap_start__;
+    __msp_stack_limit__ = __aymos_heap_end__;
+    __msp_stack_top__ = _estack;
+    _end = __newlib_heap_start__;
+    end = _end;
+    _img_end = __aymos_heap_start__;
+
+    /DISCARD/ :
+    {
+        *(.note.GNU-stack)
+        *(.gnu_debuglink)
+        *(.gnu.lto_*)
+    }
+}
+
+ASSERT(__vector_table_start__ == ORIGIN(FLASH), "vector table must start at flash origin")
+ASSERT((__vector_table_start__ & 0x1ff) == 0, "vector table must be 0x200 aligned")
+ASSERT(__vector_table_end__ <= ORIGIN(FLASH) + 0x200, "F401 vector table exceeds alignment slot")
+ASSERT(__aymos_heap_start__ <= __aymos_heap_end__, "RAM image overlaps MSP reservation")
+ASSERT((__aymos_heap_start__ & 7) == 0, "AymOS heap must be eight-byte aligned")
+ASSERT(__newlib_heap_start__ == __newlib_heap_end__, "newlib heap must remain disabled")
+ASSERT(__msp_stack_top__ == ORIGIN(RAM) + LENGTH(RAM), "MSP top must equal RAM end")

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -2,6 +2,12 @@
 
 This document describes the public functions provided by AymOS. Each section lists the function prototype, its parameters, the return value and any notes about its usage.
 
+> **Experimental source inventory:** These APIs are present in the legacy
+> kernel/allocator source but are not linked into the PR 1 boot firmware. Their
+> lifecycle, timing, and memory contracts are not yet trustworthy. They become
+> supported only as later implementation-plan gates add architecture and native
+> tests.
+
 ## Task Management
 
 ### `void osKernelInit(void)`
@@ -53,4 +59,3 @@ Free a block previously allocated with `k_mem_alloc`. Returns `RTX_OK` on succes
 
 ### `int k_mem_count_extfrag(unsigned int size)`
 Return the number of free blocks that are too small to satisfy an allocation of `size` bytes.
-

--- a/docs/BUILDING.md
+++ b/docs/BUILDING.md
@@ -1,0 +1,170 @@
+# Reproducible F401RE build
+
+## Supported environment
+
+PR 1 supports Linux x86_64. The bootstrap requires:
+
+- `awk`;
+- Bash;
+- Git 2.25 or newer (sparse checkout and partial clone support);
+- curl 7.61 or newer;
+- GNU Make;
+- `file`, `grep`, `od`, `sha256sum`, `stat`, `tar`, and `xz`; and
+- network access during `make setup`.
+
+No root access, container daemon, global ARM compiler, or global STM32 headers
+are used. The Makefile rejects command-line or environment definitions of
+`ARM_GNU_DIR`, `CROSS_COMPILE`, `CC`, `OBJCOPY`, `OBJDUMP`, `READELF`, `SIZE`,
+and `NM`; this prevents a caller, including `make -e`, from bypassing the
+locked-tool integrity gate. `BOARD` and `APP` remain ordinary documented build
+selectors. Arm's x86_64 toolchain is built on RHEL 8; hosts older than RHEL 8 or
+Ubuntu 20.04 may lack compatible runtime libraries. Setup executes the compiler
+and reports that failure rather than allowing a later, ambiguous build error.
+
+Only Linux x86_64 is claimed in this PR. Other host architectures must add and
+validate their own locked tool archive instead of falling back to `PATH`.
+Likewise, any future user-selectable tool path must first implement the same
+selected-path and content-hash validation and record the selection in build
+metadata. Arbitrary tool overrides are not a supported escape hatch.
+
+## Install the locked inputs
+
+```sh
+make setup
+```
+
+Inputs are declared in `tools/setup/dependencies.lock`:
+
+- Arm GNU Toolchain 14.3.rel1 for x86_64 `arm-none-eabi`;
+- CMSIS Core from STM32CubeF4 v1.28.3;
+- the STM32F4 CMSIS device commit referenced by that Cube release; and
+- the STM32F4 HAL commit referenced by that Cube release.
+
+The Arm archive byte size and SHA-256 are checked before extraction. Every
+consumed Arm executable (`gcc`, `as`, `ld`, `nm`, `objcopy`, `objdump`,
+`readelf`, and `size`) is checked against a locked digest, and an installation
+manifest ties them back to the verified archive. STM32 dependencies are checked
+for exact HEAD and for modified/untracked files. Required sources, headers, and
+licenses are validated. The Cube parent is blob-filtered and sparse: projects,
+middleware, and excluded blobs are not downloaded.
+
+Setup uses a repository-local concurrency lock. Interrupted temporary paths use
+unique names and are cleaned on normal exit, SIGINT, and SIGTERM. A complete
+`.part` is verified and promoted without asking curl to resume it; invalid or
+oversized partial files are quarantined instead of causing a persistent HTTP
+416 loop.
+
+`.tools/` and `.deps/` are ignored. They are immutable build inputs: setup
+refuses to reset or overwrite local dependency changes.
+
+`tools/setup.sh --check` is the offline/read-only validation mode. The Makefile
+uses it as an ordering gate for every object, so even `make -j` cannot compile
+before dependency/tool integrity and cleanliness pass.
+
+## Build and validate
+
+```sh
+make firmware
+```
+
+This is equivalent to:
+
+```sh
+make firmware BOARD=nucleo_f401re APP=boot
+```
+
+The Makefile invokes the compiler by its absolute project-local path. Project
+code uses `-Wall -Wextra -Werror` plus additional diagnostics. Vendor code uses
+visible `-Wall -Wextra` warnings without converting upstream warnings into
+project errors. Source lists are explicit and application selection fails for
+unknown names.
+
+The output directory is `build/nucleo_f401re/boot/`. The build produces:
+
+- `aymos.elf`: debug-enabled ARM executable;
+- `aymos.bin`: flashable raw image;
+- `aymos.map`: linker map and cross-reference;
+- `size.txt`: Berkeley-format size report;
+- `build-metadata.txt`: board, app, Git state, compiler, flags, dependency
+  revisions, and successful integrity/clean-state fields; and
+- inspection artifacts from `file`, `readelf`, `nm`, `objdump`, and the raw
+  vector section.
+
+Validation checks:
+
+- ELF32 little-endian ARM, EABI5, ARMv7E-M/Thumb-2, soft-float ABI;
+- absence of hard-float procedure-call attributes;
+- loadable/allocated sections contained in 512 KiB flash or 96 KiB SRAM;
+- the complete vector table at `0x08000000`, aligned to `0x200`;
+- actual initial vector words equal to the linked MSP top and Thumb
+  `Reset_Handler`;
+- every PT_LOAD has `MemSiz >= FileSiz`, fits its VMA in F401RE flash/SRAM,
+  keeps every non-empty file payload LMA in flash, and includes a non-empty
+  segment whose VMA and LMA both start at the flash origin;
+- ELF entry equals `Reset_Handler | 1`;
+- focused disassembly confirms that reset calls `SystemInit` before `main`;
+- `Reset_Handler` resides in flash;
+- eight-byte-aligned custom heap boundaries;
+- an empty newlib heap that cannot overlap the AymOS heap;
+- a 4 KiB MSP reservation ending at `0x20018000`; and
+- corresponding heap/stack symbols in the map.
+
+The validator retains `reset-handler-disassembly.txt` and
+`system-init-disassembly.txt`. The reset call order is checked automatically.
+The PR 1 review manually inspects the SystemInit artifact for the VTOR store;
+the validator does not claim to semantically prove arbitrary disassembly.
+
+Run validation again without recompiling:
+
+```sh
+make validate
+```
+
+Generate source/assembly disassembly:
+
+```sh
+make disassembly
+```
+
+## Clean reproduction
+
+Build products can be removed and regenerated without reinstalling tools:
+
+```sh
+make clean
+make firmware
+```
+
+To exercise dependency bootstrap from scratch, move or delete only the explicit
+ignored `.tools/` and `.deps/` directories, then run:
+
+```sh
+make setup
+make setup
+make firmware
+```
+
+The second setup invocation proves idempotence. Do not point cleanup commands at
+the repository root or a home directory.
+
+## Memory ownership in PR 1
+
+The linker reserves all free SRAM between `.bss` and the 4 KiB MSP region as
+the AymOS heap and exports `__aymos_heap_start__`/`__aymos_heap_end__`. Those
+boundaries are eight-byte aligned. The newlib heap start and end are identical,
+and the retained `_sbrk` implementation always returns `ENOMEM`.
+
+The legacy AymOS allocator is not linked into the boot app. Its later hardening
+will consume the already-reserved linker region. PR 1 therefore establishes
+non-overlapping ownership without claiming that the allocator itself is fixed.
+
+## Application and hardware status
+
+Startup `SystemInit` configures VTOR before `APP=boot` initializes HAL, an
+84 MHz HSI/PLL clock, PA5, and USART2. The app then emits
+`AYMOS BOOT F401RE` and waits for interrupts. SysTick only advances the HAL
+tick; it does not call legacy scheduler code.
+
+Renode boot/testing is PR 2. Physical flashing is not validated. `make flash`
+builds the binary, prints that limitation, and exits nonzero rather than running
+an undocumented global programmer.

--- a/docs/FUNCTIONALITY_OVERVIEW.md
+++ b/docs/FUNCTIONALITY_OVERVIEW.md
@@ -2,6 +2,10 @@
 
 This document explains the main modules of AymOS and how they work together. It supplements the information in the README.
 
+> **Status:** The kernel and allocator below describe legacy experimental
+> source. PR 1 builds only the F401RE boot application and board support. It
+> does not link or validate task switching, EDF timing, or the allocator.
+
 ## Kernel
 
 The kernel (`src/kernel.c`) is responsible for task management and scheduling. It maintains an array of Task Control Blocks (TCBs) representing each task's stack, priority, and state. Tasks are scheduled using an Earliest Deadline First (EDF) policy. Key functions include:
@@ -37,8 +41,12 @@ Several small test programs under `src/tests` demonstrate the kernel and memory 
 - `allocation_timing_test.c` – measures memory allocation performance.
 - `periodic_test.c` – exercises periodic task behaviour.
 
-Running `make` builds the tests using the ARM toolchain specified in the `Makefile`.
+These files are manual firmware experiments with separate `main` functions;
+they are not selected by the current build and are not an automated test suite.
+The staged campaign will replace them with native and Renode tests.
 
 ## Next Steps
 
-To deepen your understanding of AymOS, inspect the tests and experiment with writing new tasks. Study the ARM exception handlers in `svc_handler.s` to see how registers are saved and restored during a context switch.
+For the verified build workflow, use `make setup && make firmware` and read
+`docs/BUILDING.md`. Study the legacy exception handlers as prototype code, not
+as a currently verified context-switch implementation.

--- a/docs/IMPLEMENTATION_PLAN.md
+++ b/docs/IMPLEMENTATION_PLAN.md
@@ -1,0 +1,865 @@
+# AymOS Real-Time Systems Lab implementation plan
+
+Status: feasibility reviewed; PR 1 implementation authorized
+
+This document defines the first trustworthy vertical slice of AymOS. It is a
+campaign plan, not a claim that the described target behavior exists today.
+Each pull request (PR) must update the README and this document when evidence
+changes a design decision.
+
+### Feasibility review record
+
+Lead feasibility review completed before PR 1 implementation. The draft was
+corrected to:
+
+- pin Renode v1.16.1's portable .NET archive and integrity hash and account for
+  `renode-test` Python requirements;
+- reuse the STM32F4 model only through a reviewed F401RE-sized, 84 MHz,
+  slice-accurate platform definition;
+- remove the generic platform's unpinned remote SVD fetch, retain required
+  peripheral tags, and test that emulator runs need no undeclared network after
+  setup;
+- use a pinned rootless CPython runtime for Renode/host tools rather than an
+  undocumented system Python environment;
+- distinguish reset's address-zero vector fetch from subsequent VTOR-based
+  exception dispatch, set VTOR in `SystemInit` before HAL/SysTick, and align the
+  complete F401 vector table to its required boundary;
+- keep PR 2's SysTick/SVC smoke application-local (counter/flag handlers with
+  thread-mode reporting), leaving SVC/PendSV/PSP task evidence to PR 3;
+- require exact-one banner validation from raw UART bytes with inner Robot and
+  outer host timeouts; and
+- define naturally aligned 32-byte trace records, selection snapshots,
+  drop-new overflow, an always-observable loss footer, and strict parser
+  completeness checks.
+
+These findings are resolved in the plan. Their implementation evidence remains
+owned by the corresponding PR acceptance gates.
+
+## Product objective and evidence standard
+
+AymOS is intended to be a small, inspectable Cortex-M4 real-time systems lab.
+The first release will execute deterministic workloads in Renode, emit enough
+kernel state to explain EDF decisions, and render those events as a host-side
+timeline. The firmware loaded by Renode will be the same STM32F401RE ELF built
+for the NUCLEO-F401RE. There will be no host-side scheduler substituted for the
+SVC, PendSV, PSP, and SysTick paths.
+
+The target workflow is:
+
+```sh
+make setup
+make firmware
+make test
+make run
+make test-emulator
+make timeline
+```
+
+`make setup` may require network access, but it must not require root access or
+an undocumented system-wide ARM compiler or Renode installation. Every
+downloaded executable and source dependency will be version-locked and
+integrity-checked. Build and run metadata will record the resolved versions.
+
+Passing in Renode demonstrates functional behavior in that emulator. It does
+not establish physical interrupt latency, worst-case execution time, hardware
+timing, or a hard real-time guarantee. Physical NUCLEO-F401RE support remains
+unverified until a named hardware test has actually been performed and its
+result recorded.
+
+## Re-verified current architecture
+
+The repository currently contains a compact, single-address-space kernel and
+board support prototype:
+
+- `stm-startup/startup_stm32f401retx.s` contains an STM32F401xE reset handler
+  and vector table. Reset initializes `.data` and `.bss`, calls `SystemInit`,
+  calls `__libc_init_array`, and enters `main`.
+- `src/util.c`, `src/stm32f4xx_hal_msp.c`, and `headers/main.h` describe a
+  NUCLEO-F401RE-like board: USART2 on PA2/PA3, the user LED on PA5, and the user
+  button on PC13. The configured clock is 84 MHz and UART is 115200 8N1.
+- `src/kernel.c` keeps 16 static TCB slots, reserves slot 0 for idle, scans
+  READY tasks for the smallest `time_remaining`, and uses `priority` as an
+  equal-deadline tie breaker.
+- Task stacks are allocated from `src/memory.c` and initialized with a
+  hand-built Cortex-M exception frame. `src/svc_handler.s` decodes SVC through
+  a C handler and uses PendSV to save and restore R4-R11 on the PSP.
+- `src/memory.c` implements an in-heap linked-list allocator with splitting,
+  ownership metadata, next-fit state, and coalescing.
+- Seven files under `src/tests/` are manually selected alternative firmware
+  entry points, not an automated test suite.
+
+The intended control flow is:
+
+```text
+Reset_Handler -> SystemInit -> main -> HAL/board initialization
+                                  -> osKernelInit
+                                  -> task creation
+                                  -> osKernelStart -> SVC -> PendSV
+                                  -> thread mode on PSP
+
+SysTick -> release/time update -> request PendSV
+PendSV  -> save old R4-R11 -> select/commit next task -> restore R4-R11
+```
+
+This flow is not functional on `main` at the start of the campaign. The
+following findings were re-verified rather than inherited from the audit:
+
+- The Makefile searches `Src/` and `Inc/`, while the repository uses `src/`
+  and `headers/`. `make -n` therefore links with an empty object list.
+- It references an absent `STM32F407VGTx_FLASH.ld` despite the F401RE startup
+  file and board pinout.
+- It does not include `stm-startup/`, CMSIS, or STM32 HAL sources. Those
+  dependencies are not present in the checkout.
+- The current host has neither `arm-none-eabi-gcc` nor `renode`; plain `make`
+  fails at the first compiler invocation.
+- `src/main.c` is an obsolete one-stack SVC experiment. It does not initialize
+  the kernel or create a kernel-managed task.
+- `src/stm32f4xx_it.c` refers to obsolete symbols (`kernel_running`,
+  `current_TID`, `next_TID`, `g_system_time`, `svc_number`, and
+  `getEarliestDeadlineTask`) rather than the names currently defined by the
+  kernel.
+- SysTick is assigned a lower urgency than PendSV. PendSV should be the
+  lowest-urgency exception so it cannot interrupt kernel tick bookkeeping.
+- Yield chooses a task before making the current task READY, and the switch
+  helper does not consistently establish the selected task as RUNNING.
+- The fabricated task frame has no task argument or return trampoline. Task
+  exit deallocates the stack while it is still the active PSP stack.
+- `deadline` and `time_remaining` currently conflate period, wake delay,
+  release, deadline, and countdown semantics.
+- The allocator hard-codes a 24-byte header, aligns to only four bytes, and has
+  unsafe next-fit edge cases. Its heap and `_sbrk` both span from the image end
+  toward the reserved MSP region.
+- The Makefile requests the hard-float ABI, but PendSV does not preserve the
+  high floating-point registers.
+- README statements about protected memory, synchronization, comprehensive
+  interrupt management, and a clean build are not supported by the code.
+
+These are gates for later PRs, not reasons to redesign everything in PR 1.
+
+## Target repository structure
+
+The repository will move toward this layout incrementally. PRs should avoid
+large moves unrelated to their acceptance criteria and preserve useful Git
+history.
+
+```text
+apps/
+  boot/                    minimal board smoke application
+  lifecycle/               task lifecycle integration scenario
+  deadline_lab/            deterministic product demo
+arch/
+  arm_cm4/                 startup, SVC/PendSV, exception helpers
+bsp/
+  nucleo_f401re/           clock, GPIO, UART, linker script, HAL configuration
+include/aymos/              public kernel API
+kernel/
+  allocator/               educational bounded allocator
+  scheduler/               portable scheduler policy and timing state
+  trace/                   fixed-size trace records and ring
+  *.c                      task lifecycle and kernel coordination
+platform/
+  renode/                  F401RE platform description and launch scripts
+tests/
+  native/                  host scheduler, allocator, parser, and schema tests
+  renode/                  black-box ARM firmware tests
+tools/
+  aymos_lab/               trace collection, parser, summaries, timeline CLI
+  setup/                   dependency lock and setup helpers
+docs/
+  IMPLEMENTATION_PLAN.md
+  TRACE_FORMAT.md
+third_party/
+  README.md                provenance and licenses, not mutable build output
+build/                     ignored build products
+.deps/                     ignored pinned source dependencies
+.tools/                    ignored pinned executable tools
+runs/                      ignored generated runs except curated examples
+```
+
+Applications are link-time selections, not runtime-loaded programs. The build
+will accept an explicit name, for example `make firmware APP=boot`, and will
+fail on unknown names. The default application will be documented in `make
+help` and the README. Each application contributes an explicit source manifest;
+wildcarding every C file under a tree is prohibited because several existing
+test files define `main`.
+
+## Dependency and toolchain strategy
+
+### Locking and local installation
+
+A machine-readable lock file under `tools/setup/` will record, for every
+dependency:
+
+- upstream URL;
+- release/tag and immutable commit where applicable;
+- archive filename;
+- SHA-256 for downloaded archives;
+- license location;
+- supported host architecture.
+
+`make setup` will invoke a small, auditable shell helper that:
+
+1. validates basic host tools (`bash`, `make`, `git`, `curl`, `tar`, `xz`, and
+   a SHA-256 utility);
+2. downloads into a temporary file;
+3. verifies SHA-256 before extraction;
+4. installs under `.tools/` or `.deps/` without root;
+5. verifies the resolved version/commit after installation; and
+6. is idempotent and safe to resume.
+
+The Makefile invokes tools by an explicit project-local path and does not
+silently fall back to a same-named executable on `PATH`. PR 1 rejects
+command-line and environment overrides of the toolchain directory, cross
+prefix, compiler, and binary utilities, including attempts made through
+`make -e`. A future non-x86_64 or advanced-user override is permitted only
+after it gains the same selected-path and content-hash validation as the
+canonical toolchain, with the selection recorded in metadata; until then it
+must fail explicitly.
+
+Download and extracted directories will be ignored by Git. Dependency source
+will not be edited in place. Project-owned and third-party compilation units
+will use separate warning variables so warnings in our code stay errors while
+unavoidable vendor diagnostics remain visible and documented.
+
+### Pinned components
+
+The initial conservative choices are:
+
+- Arm GNU Toolchain 14.3.rel1, x86_64 Linux, `arm-none-eabi`. The exact official
+  archive URL and SHA-256 must be validated against Arm's release material in
+  PR 1 before the lock is accepted.
+- STM32CubeF4 v1.28.3 as the compatibility baseline. To avoid downloading the
+  entire firmware bundle, setup will fetch only the official component repos
+  at the commits referenced by the peeled v1.28.3 commit
+  `94cae6e83f00e276a11957e7833c01ac3d0bd7af`:
+  - `stm32f4xx_hal_driver` at
+    `b6f0ed3829f3829eb358a2e7417d80bba1a42db7`;
+  - `cmsis_device_f4` at
+    `3c77349ce04c8af401454cc51f85ea9a50e34fc1`;
+  - CMSIS Core headers from the matching Cube release or an explicitly pinned
+    CMSIS release after include-level compatibility is verified.
+- Renode is pinned to v1.16.1's portable .NET Linux asset:
+  `https://github.com/renode/renode/releases/download/v1.16.1/renode-1.16.1.linux-portable-dotnet.tar.gz`,
+  SHA-256
+  `00e113cdbd0f5354cf2f64bbe3f5a070d8958409542fca66e45ac97d982938c0`.
+  PR 2 still must verify that this asset executes on the supported clean host.
+  `renode-test` also requires Python packages; those requirements will be
+  installed with exact pins/hashes into the project's local virtual environment
+  rather than resolved from the user's Python environment.
+- Python is a project-local runtime, not a system prerequisite beyond setup.
+  PR 2 will pin a CPython 3.12 x86_64 Linux install-only archive from Astral's
+  `python-build-standalone` project by release, URL, and SHA-256 under
+  `.tools/python/`. Both `renode-test` and later host tools will use a virtual
+  environment created by that interpreter with exact, hash-locked
+  requirements. The final archive build and hash are a PR 2 lock-file review
+  item; `python3`, `venv`, and `pip` from `PATH` are not fallback behavior.
+
+Official upstreams are the Arm GNU Toolchain release repository,
+<https://github.com/STMicroelectronics/STM32CubeF4>, its referenced component
+repositories, and <https://github.com/renode/renode>. Dependency updates must
+be isolated changes with regenerated hashes and full build/emulator testing.
+
+### Floating-point ABI
+
+Firmware will initially use Thumb-2 and the software floating-point calling
+convention (`-mcpu=cortex-m4 -mthumb -mfloat-abi=soft`). Application and all
+linked libraries must agree. Hardware floating point is deferred until the
+lazy-stacking behavior and S16-S31 preservation have architecture-level tests.
+
+## PR 1 build design
+
+PR 1 is deliberately a board/build foundation, not a scheduler repair.
+
+- Establish `nucleo_f401re` as the only supported board and
+  `STM32F401xE` as the device define.
+- Replace source wildcards with named project, board, startup, and HAL lists.
+  HAL files will come only from the locked dependency locations.
+- Add a reviewed F401RE linker script with 512 KiB flash at `0x08000000` and
+  96 KiB SRAM at `0x20000000`. The vector table will be retained at the flash
+  origin with `0x200` alignment for the complete device table, and the map will
+  export explicit vector, image, custom-heap, and MSP-stack boundaries.
+- Use the correct F401xE startup/vector assembly from the locked CMSIS device
+  package, or retain the existing file only after a byte/handler review against
+  that source. Do not compile two vector tables.
+- Set `SCB->VTOR` explicitly to the linker-exported flash vector address in
+  `SystemInit`, before `HAL_Init` enables SysTick. Runtime code must use linker
+  symbols or CMSIS constants instead of reading a presumed vector alias at
+  address zero. Reset itself still requires STM32's address-zero flash boot
+  alias (or equivalent emulator MSP/PC initialization); firmware cannot remove
+  that architectural reset requirement by writing VTOR later.
+- Give the AymOS allocator a linker-reserved, eight-byte-aligned region with
+  start/end symbols. Newlib dynamic allocation will be explicitly disabled for
+  the first slice (an `_sbrk` failure is preferable to overlapping heaps).
+  Project code in PR 1 will not call `malloc`. A future separate newlib heap
+  would require a non-overlapping linker region and a demonstrated need.
+- Replace the obsolete SVC experiment with an `apps/boot` entry point that
+  initializes the HAL, 84 MHz clock, GPIO, and USART2, emits a small boot line,
+  and idles. It will not claim that task switching works before PR 3.
+- PR 1's SysTick handler is HAL-only: it advances the HAL tick without entering
+  the stale kernel timing path. PR 3 replaces that temporary boundary with the
+  corrected kernel tick/preemption integration after lifecycle invariants exist.
+- Build the project-owned BSP and boot application with strict warnings. Keep
+  vendor compiler options and diagnostics visibly separate.
+- Produce `aymos.elf`, `aymos.bin`, `aymos.map`, a saved size report, and
+  optional disassembly under a board/application-specific build directory.
+- Add build validation using `file`, `readelf`, `objdump`/`nm`, `size`, and map
+  checks. Validate ARM EABI, Cortex-M4 attributes, soft-float ABI, the reset
+  vector/entry point, and all allocated sections against the F401RE flash/RAM
+  ranges.
+- Keep `make flash` explicit and non-default. It may build the binary and print
+  the required probe tool while remaining marked unverified when no board is
+  available.
+
+Kernel compilation may be temporarily separate from the boot application's
+link if stale interrupt code prevents a safe image. If so, PR 1 must state that
+fact prominently; PR 3 must link and exercise the real kernel. Prefer compiling
+the kernel when small non-behavioral compatibility fixes suffice, but do not
+smuggle lifecycle redesign into PR 1 merely to make the link green.
+
+## Renode integration approach
+
+PR 2 will derive a repository-owned local definition from Renode's pinned
+generic `platforms/cpus/stm32f4.repl` and apply the smallest F401RE overlay
+needed by AymOS. The local copy removes the generic definition's unpinned
+remote `ApplySVD` fetch while preserving all peripheral tags required by
+Renode's STM32 models and tests. The overlay will override flash size to
+`0x80000`, SRAM size to `0x18000`, and SysTick frequency to 84 MHz. The reviewed
+model must map:
+
+- 512 KiB flash at `0x08000000`;
+- 96 KiB SRAM at `0x20000000`;
+- an ARM Cortex-M4 CPU and NVIC;
+- SysTick through the NVIC/CPU model;
+- RCC/clock behavior sufficient for HAL initialization;
+- USART2 at its STM32F4 address with its IRQ connection;
+- GPIO blocks required by the boot application or later demo.
+
+This is a slice-accurate model for the peripherals and memory used by AymOS,
+not an exact model of every STM32F401RE register or silicon behavior.
+Unsupported peripherals and unverified register behavior will be named rather
+than implied.
+
+The harness will load the exact board ELF, expose USART2 as a host-testable
+stream, run without a GUI, and enforce a wall-clock timeout. After `make setup`,
+the emulator paths must work with network access denied; no model, SVD, Python,
+or test dependency may be fetched at run time. `make run` is the
+interactive/headless demonstration path. `make test-emulator` invokes a Robot
+test with a UART2 terminal tester timeout and wraps the entire Renode process in
+a second host-side timeout. It counts the exact banner bytes in the raw UART
+capture and requires exactly one `AYMOS READY`. After that banner, the guest
+invokes minimal application-local smoke handlers: SysTick increments a counter
+and SVC sets a flag; neither schedules, switches context, or writes UART. Thread
+mode observes the counter/flag and emits the smoke result. The test retains raw
+UART separately from `emulator.log` on every failure.
+
+Reset occurs before firmware can write VTOR: the Cortex-M reset sequence must
+still obtain initial MSP and reset PC from address zero. PR 2 must either model
+the STM32 flash boot alias at zero or explicitly configure equivalent emulator
+initial MSP/PC behavior and test it. Independently, `SystemInit` sets
+`SCB->VTOR` to the linker-exported flash vector base before `HAL_Init` enables
+SysTick, so all later exceptions use the linked table. ELF checks verify its
+initial MSP/reset PC and that the complete F401 table is aligned to `0x200`.
+Existing kernel code that reads address zero after reset will be converted to a
+linker/vector symbol before it is exercised.
+
+If HAL clock initialization hangs because the chosen RCC model does not model a
+polled hardware-ready transition, the investigation must first compare accesses
+with Renode's existing STM32F4 models. Any emulator-specific firmware bypass
+must be narrow, compile-time visible in build metadata, and must not alter the
+kernel scheduling path. A single register-level clock setup shared by emulator
+and board is preferable to divergent board code.
+
+PR 2 is a hard gate. No lifecycle integration is considered complete until the
+F401RE-targeted ELF boots reliably through this harness.
+
+## Testing layers
+
+The campaign uses complementary layers; no single layer substitutes for the
+others.
+
+### 1. Dependency and build validation
+
+- Verify hashes, source commits, and reported tool versions.
+- Re-run setup to prove idempotence.
+- Build from a checkout with project-local caches removed.
+- Fail on project-owned compiler warnings.
+- Inspect ELF identity, EABI attributes, symbols, vector placement, section
+  VMAs/LMAs, flash/RAM bounds, heap/stack separation, map file, and size.
+- Build all supported application selections, not just the default.
+
+### 2. Native policy/unit tests
+
+Portable scheduler policy, tick comparisons, allocator core logic, trace
+schema, trace parser, and timeline interval construction will be built for the
+host. Architecture dependencies must be behind narrow interfaces rather than
+stubbed throughout the kernel. Tests will use assertions and deterministic
+fixtures. Allocator tests will use AddressSanitizer and UndefinedBehaviorSanitizer
+where their host adaptation permits it.
+
+Native tests prove policy and memory algorithms; they do not prove ARM
+exception entry, stack frames, privilege state, or actual preemption.
+
+### 3. ARM/Renode integration tests
+
+Black-box tests will boot the board ELF and assert UART or structured trace
+events for:
+
+- reset and boot;
+- SVC dispatch and first PSP task;
+- voluntary yield and PendSV;
+- SysTick-driven preemption;
+- task return/exit and deferred stack reclamation;
+- deterministic EDF releases and choices;
+- repeated allocation/task reuse;
+- trace framing, overflow behavior, and end-to-end Deadline Lab runs.
+
+Every emulator command has an explicit timeout and preserves diagnostics on
+failure. Tests compare semantic event sequences, not unstable host timestamps.
+
+### 4. Host-tool contract and end-to-end tests
+
+- Validate trace headers, record sizes, enum ranges, sequence continuity,
+  checksums/framing, and truncated/corrupt input behavior.
+- Use golden traces only for parser/renderer unit tests; end-to-end acceptance
+  traces must come from the executed Cortex-M4 firmware.
+- Assert summary metrics and timeline intervals for normal and overload modes.
+- Run the one-command workflow into an isolated, bounded run directory and
+  validate its manifest and artifacts.
+
+### 5. Physical hardware tests
+
+`make flash` and a serial smoke procedure will be documented. Until run on a
+named NUCLEO-F401RE, its result is explicitly “not validated.” Renode event
+ordering must not be presented as measured board timing.
+
+## Timing model direction
+
+PR 4 will give each schedulable job explicit state rather than decrementing one
+overloaded field. The public configuration will have deterministic defaults and
+will distinguish at least:
+
+- task kind: one-shot or periodic;
+- phase/initial release tick;
+- period for periodic tasks;
+- relative deadline;
+- absolute deadline for the current job;
+- next release/wake tick;
+- release/job sequence;
+- completion/accounting state;
+- deadline-miss count;
+- sleeping versus waiting-for-release versus dormant state.
+
+Tick comparisons will use the standard half-range modular rule, expressed in
+one tested helper. Configured delays/deadlines must remain below half the
+`uint32_t` range so ordering is unambiguous. Execution demand in the Deadline
+Lab will be deterministic units driven by guest-visible work/ticks, not host
+wall time.
+
+EDF selection will compare eligible jobs by absolute deadline, then explicit
+static priority, then stable TID as the final deterministic tie breaker. Idle is
+selected only when there is no eligible user job. Deadline misses are counted
+and traced; they are not silently converted into releases.
+
+## Trace architecture
+
+PR 6 will implement a bounded, versioned trace designed for low perturbation:
+
+1. Kernel sites construct naturally aligned, 32-byte binary event records. A
+   record contains only guest tick and monotonically increasing sequence as its
+   ordering/time coordinates, plus schema version/event ID, primary and related
+   task IDs, and event-specific values. Host wall time and emulator virtual time
+   are not inserted into kernel records.
+2. Producers append records to a statically allocated single-core ring in a
+   short interrupt-safe critical section. No producer calls `printf`, waits for
+   UART, or performs allocation.
+3. A low-priority controlled flush path removes committed records and frames
+   them for USART2. Framing includes enough length/version/integrity information
+   for the host to reject corrupt or partial records and resynchronize.
+4. On a full ring, the producer uses drop-new: the attempted record is
+   discarded, existing committed history is retained, and a loss counter is
+   incremented. The run terminator/footer carries the final loss count through
+   a reserved transport path so loss remains observable even if the ring never
+   regains space. A `TRACE_OVERFLOW` record may additionally summarize loss
+   when normal space becomes available, but it is not the only evidence.
+5. The host saves raw UART bytes separately from Renode's diagnostic
+   `emulator.log`, decodes validated canonical records, and retains parser
+   diagnostics and schema version.
+
+At minimum, the schema will represent kernel start; task creation, release,
+selection, first start, preemption, yield, sleep, wake, exit; context switches;
+idle enter/leave; deadline met/missed; allocation/free; and trace overflow.
+Selection events carry the READY-set bit mask, relevant candidate deadlines,
+selected task, and an explicit tie reason (deadline, priority, stable TID, or
+idle fallback). If the fixed payload cannot contain every deadline, a defined
+selection snapshot sequence will carry the full state before the decision. The
+host must not invent kernel state that was never recorded.
+
+Schema changes require a version bump, C layout/alignment static assertions,
+host decoder tests, malformed-input tests, and documentation in
+`docs/TRACE_FORMAT.md`. The parser rejects unknown schema versions, truncated
+frames, sequence gaps, missing terminal footers, and any reported overflow for
+a run that claims to be complete.
+Repeated deterministic runs must be semantically equivalent after excluding
+explicitly documented transport-only fields.
+
+## Pull-request dependency graph and merge order
+
+The initial campaign is intentionally gated and mostly stacked because later
+acceptance tests exercise foundations introduced earlier:
+
+```text
+main
+  |
+  +-- PR 1 reproducible F401RE build
+        |
+        +-- PR 2 Renode boot harness
+              |
+              +-- PR 3 lifecycle/context correctness
+                    |
+                    +-- PR 4 explicit timing and EDF
+                          |
+                          +-- PR 5 allocator hardening
+                                |
+                                +-- PR 6 structured tracing
+                                      |
+                                      +-- PR 7 Deadline Lab/timeline
+```
+
+Each draft PR description must name its exact base and head. During the
+campaign, PR N is based on PR N-1's head. The required merge order is 1 through
+7. If the owner merges an earlier PR, descendants will be rebased onto the new
+`main` without force-updating another agent's active worktree. PR 5 is
+conceptually independent of PR 4 but remains ordered after it to keep one
+auditable integration line and because PR 6 needs both.
+
+Every substantial PR is implemented in its own branch/worktree, reviewed by an
+agent that did not implement it, corrected in that same branch, and fully
+retested. No PR is merged by the campaign agents.
+
+## Per-PR scope and acceptance criteria
+
+### PR 1: reproducible F401RE firmware build
+
+Base: `main`.
+
+Scope is the dependency lock/setup, explicit build, F401RE linker/startup/BSP,
+non-overlapping heap ownership, conservative ABI, minimal boot application,
+artifact validation, application selection, and accurate build documentation.
+Scheduler semantics are a non-goal.
+
+Acceptance evidence:
+
+- From a documented clean Linux x86_64 environment, `make setup` followed by
+  `make firmware` succeeds without a global ARM compiler or root.
+- Setup is idempotent and rejects hash/version mismatches.
+- The build has no project-owned warnings and does not conceal vendor warnings.
+- ELF, binary, map, and size report are produced at documented paths.
+- `file`/`readelf` show a 32-bit little-endian ARM EABI Cortex-M4 image using the
+  chosen soft-float ABI.
+- Vector/reset entry and loadable flash sections lie within
+  `0x08000000..0x0807ffff`; RAM sections and linker reservations lie within
+  `0x20000000..0x20017fff` without overlap.
+- The vector table and correct F401xE startup are present, and no F407 linker
+  artifact is used. The complete table is `0x200` aligned. Generated
+  disassembly is manually inspected to confirm that `SystemInit` sets VTOR to
+  its linked flash address before HAL SysTick is enabled.
+- The map proves that custom heap and MSP stack are disjoint and newlib cannot
+  allocate across the custom heap.
+- `APP=boot` is documented and unknown app names fail.
+- `make clean && make firmware` reproduces the image from the pinned local
+  dependencies. A clean-dependency setup/build is also exercised in review or
+  CI.
+- A different reviewer resolves findings on dependency integrity, linker
+  ranges, startup/vector selection, ABI consistency, warning policy, and docs.
+
+### PR 2: Renode boot harness and emulator CI
+
+Base: PR 1 head.
+
+Scope is a pinned local Renode, minimal F401RE platform, headless runner,
+USART2 capture, stable `AYMOS READY` banner, timeout/failure diagnostics,
+emulator test, and CI-equivalent command. Kernel simulation is a non-goal.
+
+Acceptance evidence:
+
+- `make run` loads the exact F401RE ELF and visibly reaches the banner.
+- `make test-emulator` exits successfully only after the raw UART capture
+  contains exactly one stable banner and thread mode reports the post-banner
+  application-local SysTick-counter and SVC-flag smoke results. The Robot
+  terminal tester and outer host process each have an explicit timeout.
+- A missing banner, guest fault, or timeout produces nonzero status and retains
+  command, Renode log, and raw UART output as separate artifacts.
+- At least ten clean repeated boots pass to expose startup races.
+- Metadata identifies Renode version, ELF hash, application, and arguments.
+- The model reuses generic `stm32f4.repl` with reviewed F401 sizing/frequency
+  overrides and documents that it is slice-accurate rather than exact silicon.
+- The local model has no unpinned `ApplySVD` URL, retains required model tags,
+  and runs with network disabled after setup.
+- Renode tests use the pinned project-local CPython and hash-locked virtual
+  environment; they never fall back to system Python packages.
+- Startup sets VTOR to the linked flash vector base and does not rely on an
+  address-zero alias after reset. Reset fetch itself is supplied by a tested
+  flash alias or equivalent explicit emulator initial MSP/PC configuration.
+- `make flash` remains honest about absent physical-board validation.
+- Independent review verifies the memory/peripheral model and ensures no
+  scheduler behavior is faked in host code.
+
+Gate: do not accept PR 3 integration until this boot is reliable.
+
+### PR 3: task lifecycle and context-switch correctness
+
+Base: PR 2 head.
+
+Scope is state-transition centralization, initial frame/trampoline/argument,
+safe return and deferred reclamation, current/next state ordering, obsolete ISR
+symbol reconciliation, PSP/MSP and EXC_RETURN correctness, PendSV/SysTick/SVC
+priorities, diagnostics, and a lifecycle firmware scenario. Timing API redesign
+is a non-goal.
+
+Acceptance evidence:
+
+- At all kernel-observable stable points, exactly one valid task is RUNNING
+  while active; every switched-out task has the correct non-RUNNING state.
+- A Renode scenario proves initial SVC dispatch, voluntary yield,
+  SysTick-triggered preemption, argument delivery, task return through the
+  trampoline, safe exit, deferred stack reclaim, and continued user/idle work.
+- Task stack allocation and fabricated frames guarantee eight-byte alignment
+  at exception boundaries in this PR; this requirement is not deferred to the
+  broader allocator hardening in PR 5.
+- The PendSV path preserves R4-R11 and uses the verified basic-frame
+  `EXC_RETURN` for thread mode/PSP under the soft-float ABI.
+- SVC decoding uses the stack selected by `EXC_RETURN`, validates the SVC site,
+  and handles unknown calls diagnostically.
+- PendSV is the lowest-urgency exception and cannot interrupt SysTick kernel
+  bookkeeping.
+- Impossible state assertions/fault output fail the emulator test rather than
+  hang invisibly.
+- An independent Cortex-M specialist signs off specifically on exception-frame
+  word order, xPSR Thumb bit, PC/LR/trampoline, R0 argument, PSP/MSP transition,
+  EXC_RETURN, SVC instruction decoding, register preservation, priorities,
+  alignment, and soft-float assumptions.
+
+Gate: do not expand timing semantics until the lifecycle scenario passes.
+
+### PR 4: explicit timing model and EDF correctness
+
+Base: PR 3 head.
+
+Scope is the explicit task/job timing model, public configuration API with
+defaults, wrap-safe comparisons, deterministic EDF/ties/slot reuse,
+miss/release accounting, native policy tests, and deterministic two-task ARM
+workload.
+
+Acceptance evidence:
+
+- Native tests cover earlier absolute deadline, priority tie, stable final tie,
+  sleeping exclusion, exact wake tick, miss recording, periodic release and
+  next deadline, wraparound, idle selection, one-shot termination, and reused
+  task slots.
+- Public callers never initialize internal TCB fields directly; rejected
+  configurations have explicit errors.
+- Misses remain observable and are not erased by release updates.
+- The same predefined two-task workload runs repeatedly in Renode and an
+  automated assertion observes the identical semantic selection sequence.
+- Native and ARM results agree on policy fixtures without using a host
+  scheduling simulation as the emulator result.
+- Independent review checks modular-time assumptions, simultaneous events,
+  boundary ticks, state transitions, deterministic ties, ISR interaction, and
+  API documentation.
+
+Gate: the deterministic scheduler sequence must pass before trace explanations
+are trusted.
+
+### PR 5: allocator hardening
+
+Base: PR 4 head.
+
+Scope is `sizeof` metadata, eight-byte alignment, safe next-fit behavior,
+pointer/header/allocation validation, double-free rejection, critical sections,
+ownership policy, task-exit cleanup decision, heap bounds, statistics, and
+native/Renode tests. A general libc allocator is a non-goal.
+
+Acceptance evidence:
+
+- Native deterministic tests cover split, exact fit, front/middle/end
+  coalescing, exhaustion/recovery, null and invalid free, interior pointer,
+  double free, ownership violation, alignment, boundary rejection,
+  fragmentation, and statistics.
+- Host-adapted tests pass with AddressSanitizer and UndefinedBehaviorSanitizer;
+  any test that cannot use them documents why.
+- Critical-section behavior is safe from task/SysTick interleaving and does not
+  leave interrupts disabled on an error path.
+- Linker/runtime assertions agree on heap start/end and every returned stack is
+  eight-byte aligned.
+- Custom and newlib heaps cannot overlap.
+- The ownership and task-exit policy is documented and tested. The likely
+  policy is deferred stack reclaim by the kernel plus explicit user allocation
+  cleanup, unless review demonstrates safe bounded release-all semantics.
+- A repeated Renode create/return/exit scenario reuses task slots and memory
+  without corruption, leaks beyond the documented policy, or changing allocator
+  invariants.
+- Independent review targets integer overflow, pointer provenance, corrupted
+  metadata, interrupt safety, stale owner IDs after slot reuse, fragmentation
+  metrics, and sanitizer test fidelity.
+
+Gate: memory-stress demonstrations remain excluded until these tests pass.
+
+### PR 6: structured kernel tracing
+
+Base: PR 5 head.
+
+Scope is the versioned fixed record schema, bounded ring, nonblocking producers,
+overflow behavior, controlled UART framing/flush, host decoder, schema docs,
+and deterministic semantic comparison. Timeline rendering is a non-goal.
+
+Acceptance evidence:
+
+- Every required event type is documented, versioned, emitted at a defined
+  state boundary, and covered by C/host schema tests.
+- Record size/layout has compile-time assertions and endian/transport behavior
+  is explicit.
+- No PendSV, SysTick, allocator critical section, or trace producer performs
+  formatted/blocking UART I/O or allocates memory.
+- Ring-full drop-new behavior cannot deadlock or corrupt memory; the terminal
+  footer makes its final loss count observable even if normal records never
+  resume.
+- The parser rejects bad version, length, checksum, enum, sequence, truncation,
+  impossible IDs, sequence gaps, missing footer, and any overflow in a claimed
+  complete run with useful diagnostics.
+- Records are naturally aligned 32-byte structures and use guest tick plus
+  sequence as their only ordering/time coordinates.
+- Selection snapshots expose READY mask, relevant absolute deadlines, winner,
+  and explicit tie reason.
+- A complete deterministic Renode run decodes successfully and two repeated
+  runs have semantically equivalent records.
+- Selection records expose the deadlines and tie-break information actually
+  used by the kernel.
+- Independent review checks producer/consumer races, nested interrupts,
+  commit visibility, overflow recursion, transport resynchronization,
+  perturbation, parser resource bounds, and schema completeness.
+
+Gate: timeline work cannot start until a complete validated guest trace exists.
+
+### PR 7: Deadline Lab workload and host timeline
+
+Base: PR 6 head.
+
+Scope is a deterministic fast sampler, controller/processor, slow telemetry,
+idle task, configurable load generator, normal and overload configurations,
+one-command run capture, summaries, standalone HTML timeline, bounded artifact
+layout, and end-to-end documentation. A browser service or broad experiment
+framework is a non-goal.
+
+Acceptance evidence:
+
+- A single documented command generates a complete normal run and a complete
+  overload run from guest firmware execution.
+- Normal mode meets all configured deadlines; overload mode produces a
+  reproducible first miss.
+- Automated tests assert releases, selections, running intervals, preemptions,
+  idle intervals, absolute deadline markers, and the first miss with its
+  preceding emitted scheduling evidence.
+- Timeline explanations cite emitted state rather than reconstructing hidden
+  policy.
+- Each run contains `metadata.json`, `workload.yaml`, `firmware.elf`,
+  `firmware.map`, `trace.bin`, `trace.json`, `summary.json`, `timeline.html`, and
+  `emulator.log`.
+- Metadata contains Git commit and dirty state, ELF hash, toolchain and Renode
+  versions, build configuration, workload/hash, emulator arguments, schema
+  version, and random seed or an explicit “none.”
+- Run IDs are collision-safe but reproducibility comparisons use content
+  metadata, not directory names. Retention is bounded and never deletes outside
+  the explicit `runs/` target.
+- HTML is standalone, opens locally, and renders without a server. Host
+  dependencies are locked in a project virtual environment.
+- Independent review checks trace-to-interval correctness, simultaneous event
+  ordering, empty/corrupt input, escaping, artifact provenance, deterministic
+  overload, timeout cleanup, and scope.
+
+## Review and PR quality protocol
+
+Before implementation, the lead assigns non-overlapping file ownership and a
+dedicated worktree/branch. The implementer records exact commands and raw result
+artifacts. The lead reviews every diff. A different agent performs adversarial
+review against correctness, architecture assumptions, undefined behavior,
+interrupt safety, alignment, failures, tests, documentation, and scope.
+
+Architecture-sensitive PRs explicitly review exception frames, EXC_RETURN,
+PSP/MSP transitions, eight-byte alignment, SVC decoding, PendSV/SysTick
+priorities, register preservation, and floating-point ABI. A documentation-only
+response cannot close a behavioral defect. Each finding is fixed, rejected with
+evidence, or left open and the PR marked blocked. All affected build, native,
+and Renode tests are rerun after changes.
+
+Every draft PR description includes:
+
+- problem and scope;
+- design decisions;
+- files/modules changed;
+- exact test and demonstration commands;
+- test results and retained artifacts;
+- known limitations and non-goals;
+- exact base/head and dependencies;
+- reviewer findings and resolutions;
+- generated timeline/screenshots when useful; and
+- one judgment: ready for final review, blocked, or needs another pass.
+
+A green compile alone is never sufficient. Campaign agents never merge or mark
+an unresolved PR complete.
+
+## Explicitly deferred features
+
+The first campaign does not implement:
+
+- a general-purpose shell;
+- message queues, semaphores, mutexes, or event flags;
+- networking, filesystems, USB, or dynamic executable loading;
+- multiple architecture ports, SMP, or MPU-backed process isolation;
+- POSIX compatibility;
+- AI scheduling;
+- large experiment sweeps or commit-to-commit benchmark dashboards;
+- a full browser application; or
+- hard real-time performance claims.
+
+Hardware FPU context support is also deferred while the firmware uses the
+soft-float ABI. A later diagnostic UART command interface may be proposed after
+the vertical slice, but is not part of these PRs.
+
+## Documentation policy
+
+The README will separate “implemented and tested,” “implemented but
+experimental,” “planned,” and “hardware-only/not validated.” It will not call
+allocator metadata memory protection, claim synchronization primitives or
+comprehensive interrupt management, claim clean-checkout builds before PR 1,
+or equate emulator behavior with hardware timing. Malformed encoding in
+architecture names will be corrected when encountered. Each PR changes claims
+only after its own acceptance evidence exists.
+
+## Known risks and unresolved decisions
+
+| Risk or decision | Current position | Resolution gate |
+|---|---|---|
+| Renode F401RE model completeness | Reuse generic `stm32f4.repl` with `0x80000` flash, `0x18000` SRAM, and 84 MHz SysTick overrides. This is slice-accurate, not exact silicon; do not assume HAL RCC polling works. | Focused PR 2 boot experiment before kernel integration. |
+| Renode generic model fetches an unpinned SVD | Use a reviewed local derivative with remote `ApplySVD` removed and required tags preserved; emulator commands run offline after setup. | Static URL scan plus network-denied PR 2 boot/test. |
+| Reset versus VTOR | Reset still needs vectors at address zero before `SystemInit`; later exceptions use the `0x200`-aligned flash table through VTOR. | PR 1 ELF/VTOR checks and PR 2 boot-alias or explicit MSP/PC test. |
+| Exact Arm archive URL/hash | 14.3.rel1 x86_64 `arm-none-eabi` is selected provisionally. | Verify official SHA-256 and run clean setup in PR 1. |
+| CMSIS Core source | Use the Core headers compatible with CubeF4 v1.28.3, fetched minimally. | Compile/include audit and lock review in PR 1. |
+| Existing versus vendor startup | Only one F401xE vector table may link. Vendor startup is preferred unless review validates the local copy. | ELF/vector review in PR 1. |
+| HAL versus register-level board setup | HAL is retained initially because the repository already uses it; only required modules are compiled. | PR 2 RCC/UART experiment. |
+| Kernel excluded from PR 1 boot link | Acceptable only if clearly reported and PR 3 links it; prefer inclusion after small compatibility fixes. | PR 1 feasibility review. |
+| Newlib heap | Dynamic newlib allocation is disabled initially so the custom heap is the sole dynamic allocator. | Map and `_sbrk` tests in PR 1; revisit only with demonstrated need. |
+| `printf` in boot path | Avoid dynamic/formatted output where a fixed UART write suffices. | Link/map/runtime check in PRs 1-2. |
+| Exception-frame correctness | Existing assembly is not trusted merely because it links. | Independent architecture review and Renode lifecycle test in PR 3. |
+| Tick wraparound contract | Durations below half the 32-bit range; central modular comparison helper. | Native boundary tests in PR 4. |
+| Allocator ownership on task exit | Deferred stack reclaim is mandatory; automatic release of all other task allocations is undecided. | Explicit policy plus adversarial review in PR 5. |
+| Trace record/wire encoding | Naturally aligned 32-byte records, guest tick/sequence ordering, selection snapshots, drop-new, and terminal loss footer are fixed directions; exact field packing/framing remains open. | Schema review and corrupt-stream tests in PR 6. |
+| Trace perturbation | Events change guest execution cost even without blocking output. Treat results as explanatory ordering, not timing proof. | Record overflow/loss and document in PR 6. |
+| Deterministic execution demand | Use deterministic guest work/release units; never host wall-clock loops. | Repeated semantic traces in PRs 4 and 7. |
+| Python/Plotly footprint | Plotly is acceptable only as a locked host dependency and standalone output; a smaller renderer remains possible. | PR 7 prototype and dependency review. |
+| Python bootstrap reproducibility | Install a pinned CPython 3.12 `python-build-standalone` archive locally, then use hash-locked virtual environments; no system-Python fallback. | Exact runtime asset/hash and clean offline-after-setup test in PR 2. |
+| Physical board behavior | No board is currently available in the stated environment. | Remains explicitly unverified until a recorded hardware run. |
+
+When a gate fails, dependent work stops. The exact failure and artifacts are
+recorded, a focused investigation repairs the owning PR, affected tests rerun,
+and work resumes only after the gate passes. Host tooling must never hide or
+reinterpret a kernel failure to obtain a passing demonstration.

--- a/third_party/README.md
+++ b/third_party/README.md
@@ -1,0 +1,31 @@
+# Third-party dependencies
+
+Third-party source and executable packages are not vendored into this
+repository. `make setup` installs the immutable inputs declared in
+`tools/setup/dependencies.lock` under ignored `.deps/` and `.tools/`
+directories. The build never searches global include or toolchain paths.
+
+The PR 1 dependency set is:
+
+| Component | Locked source | License retained after setup |
+|---|---|---|
+| Arm GNU Toolchain | Arm 14.3.rel1 x86_64 `arm-none-eabi` official archive | Toolchain `share/doc` and manifest files |
+| CMSIS Core (M) | `STM32CubeF4` v1.28.3, sparse checkout of `Drivers/CMSIS/Core/Include` | `Drivers/CMSIS/LICENSE.txt` (Apache-2.0) |
+| STM32F4 CMSIS device | `cmsis_device_f4` commit referenced by CubeF4 v1.28.3 | Upstream repository license (Apache-2.0) |
+| STM32F4 HAL | `stm32f4xx_hal_driver` commit referenced by CubeF4 v1.28.3 | Upstream repository license (BSD-3-Clause) |
+
+Only CMSIS Core headers and the two named STM32 driver repositories are
+fetched. STM32Cube projects, middleware, examples, and click-through/restricted
+components are not downloaded or compiled. The Cube checkout is both sparse and
+blob-filtered, so excluded project/middleware blobs are not transferred.
+
+PR 1 setup supports Linux x86_64 with Git 2.25 or newer and curl 7.61 or
+newer. It also validates `bash`, `file`, `grep`, `make`, `sha256sum`, `stat`,
+`tar`, and `xz`. Arm builds this toolchain on RHEL 8; hosts older than RHEL 8 or
+Ubuntu 20.04 may lack required runtime libraries and are not claimed as
+supported. Setup executes the compiler and fails clearly if its runtime is not
+compatible.
+
+The authoritative URLs, commits, archive byte size, and archive SHA-256 are in
+the lock file. Updating a dependency requires an isolated lock change plus a
+clean setup, build, ELF validation, and license review.

--- a/tools/setup.sh
+++ b/tools/setup.sh
@@ -1,0 +1,450 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+export LC_ALL=C
+
+readonly script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+readonly repo_root="$(cd -- "${script_dir}/.." && pwd)"
+readonly lock_file="${script_dir}/setup/dependencies.lock"
+
+# The lock file is project-owned input and intentionally uses shell assignments.
+# shellcheck source=tools/setup/dependencies.lock
+source "${lock_file}"
+
+readonly tools_dir="${repo_root}/.tools"
+readonly deps_dir="${repo_root}/.deps"
+readonly downloads_dir="${tools_dir}/downloads"
+readonly toolchain_dir="${tools_dir}/${ARM_GNU_DIRECTORY}"
+readonly toolchain_marker="${toolchain_dir}/.aymos-install-manifest"
+readonly setup_lock_dir="${tools_dir}/setup.lock"
+temporary_paths=()
+setup_lock_owned=false
+
+die() {
+    printf 'setup: error: %s\n' "$*" >&2
+    exit 1
+}
+
+note() {
+    printf 'setup: %s\n' "$*"
+}
+
+cleanup_temporary_paths() {
+    local path
+
+    for path in "${temporary_paths[@]}"; do
+        case "${path}" in
+            "${tools_dir}"/.extract-*|"${deps_dir}"/.*.fetch-*)
+                [[ ! -e "${path}" ]] || rm -rf -- "${path}"
+                ;;
+            *)
+                printf 'setup: refusing to clean unexpected temporary path: %s\n' \
+                    "${path}" >&2
+                ;;
+        esac
+    done
+
+    if [[ "${setup_lock_owned}" == true && -d "${setup_lock_dir}" ]]; then
+        rm -f -- "${setup_lock_dir}/pid"
+        rmdir -- "${setup_lock_dir}"
+    fi
+}
+
+trap cleanup_temporary_paths EXIT
+trap 'exit 130' INT
+trap 'exit 143' TERM
+
+require_command() {
+    command -v "$1" >/dev/null 2>&1 || die "required host command not found: $1"
+}
+
+version_at_least() {
+    local actual="$1"
+    local required_major="$2"
+    local required_minor="$3"
+    local major="${actual%%.*}"
+    local rest="${actual#*.}"
+    local minor="${rest%%.*}"
+
+    [[ "${major}" =~ ^[0-9]+$ && "${minor}" =~ ^[0-9]+$ ]] || return 1
+    ((major > required_major || (major == required_major && minor >= required_minor)))
+}
+
+sha256_file() {
+    sha256sum "$1" | awk '{print $1}'
+}
+
+archive_matches() {
+    local archive_path="$1"
+    local expected="$2"
+    local expected_size="$3"
+    local actual
+    local actual_size
+
+    [[ -f "${archive_path}" ]] || return 1
+    actual="$(sha256_file "${archive_path}")"
+    actual_size="$(stat -c '%s' "${archive_path}")"
+    [[ "${actual}" == "${expected}" && "${actual_size}" == "${expected_size}" ]]
+}
+
+quarantine_file() {
+    local path="$1"
+    local reason="$2"
+    local quarantine="${path}.rejected-${reason}-$$"
+
+    mv -- "${path}" "${quarantine}"
+    note "quarantined invalid download as ${quarantine}"
+}
+
+prepare_toolchain_archive() {
+    local archive_path="$1"
+    local partial_path="$2"
+    local size
+    local digest
+
+    if archive_matches "${archive_path}" "${ARM_GNU_SHA256}" "${ARM_GNU_SIZE}"; then
+        return
+    elif [[ -f "${archive_path}" ]]; then
+        quarantine_file "${archive_path}" archive
+    fi
+
+    if [[ -f "${partial_path}" ]]; then
+        size="$(stat -c '%s' "${partial_path}")"
+        if ((size == ARM_GNU_SIZE)); then
+            if archive_matches "${partial_path}" "${ARM_GNU_SHA256}" "${ARM_GNU_SIZE}"; then
+                mv -- "${partial_path}" "${archive_path}"
+                return
+            fi
+            quarantine_file "${partial_path}" checksum
+        elif ((size > ARM_GNU_SIZE)); then
+            quarantine_file "${partial_path}" oversized
+        fi
+    fi
+
+    note "downloading Arm GNU Toolchain ${ARM_GNU_VERSION}"
+    curl --fail --location --retry 3 --silent --show-error --continue-at - \
+        --output "${partial_path}" "${ARM_GNU_URL}"
+    if ! archive_matches "${partial_path}" "${ARM_GNU_SHA256}" "${ARM_GNU_SIZE}"; then
+        size="$(stat -c '%s' "${partial_path}")"
+        digest="$(sha256_file "${partial_path}")"
+        quarantine_file "${partial_path}" downloaded
+        die "downloaded toolchain mismatch: expected ${ARM_GNU_SIZE}/${ARM_GNU_SHA256}, got ${size}/${digest}"
+    fi
+    mv -- "${partial_path}" "${archive_path}"
+}
+
+tool_hash() {
+    case "$1" in
+        as) printf '%s\n' "${ARM_GNU_AS_SHA256}" ;;
+        gcc) printf '%s\n' "${ARM_GNU_GCC_SHA256}" ;;
+        ld) printf '%s\n' "${ARM_GNU_LD_SHA256}" ;;
+        nm) printf '%s\n' "${ARM_GNU_NM_SHA256}" ;;
+        objcopy) printf '%s\n' "${ARM_GNU_OBJCOPY_SHA256}" ;;
+        objdump) printf '%s\n' "${ARM_GNU_OBJDUMP_SHA256}" ;;
+        readelf) printf '%s\n' "${ARM_GNU_READELF_SHA256}" ;;
+        size) printf '%s\n' "${ARM_GNU_SIZE_SHA256}" ;;
+        *) die "no locked digest for ARM tool: $1" ;;
+    esac
+}
+
+write_toolchain_marker() {
+    local compiler="${toolchain_dir}/bin/arm-none-eabi-gcc"
+    local compiler_digest
+    local tool
+
+    compiler_digest="$(sha256_file "${compiler}")"
+    [[ "${compiler_digest}" == "${ARM_GNU_GCC_SHA256}" ]] ||
+        die "installed compiler checksum does not match the locked archive"
+    {
+        printf 'marker_version=1\n'
+        printf 'archive=%s\n' "${ARM_GNU_ARCHIVE}"
+        printf 'archive_sha256=%s\n' "${ARM_GNU_SHA256}"
+        printf 'archive_size=%s\n' "${ARM_GNU_SIZE}"
+        for tool in as gcc ld nm objcopy objdump readelf size; do
+            printf 'tool_sha256.arm-none-eabi-%s=%s\n' "${tool}" "$(tool_hash "${tool}")"
+        done
+    } > "${toolchain_marker}"
+}
+
+validate_toolchain_marker() {
+    local compiler="${toolchain_dir}/bin/arm-none-eabi-gcc"
+    local tool
+    local expected
+
+    [[ -f "${toolchain_marker}" ]] || die "toolchain install marker is missing"
+    grep -Fxq 'marker_version=1' "${toolchain_marker}" ||
+        die "toolchain marker version mismatch"
+    grep -Fxq "archive=${ARM_GNU_ARCHIVE}" "${toolchain_marker}" ||
+        die "toolchain marker archive mismatch"
+    grep -Fxq "archive_sha256=${ARM_GNU_SHA256}" "${toolchain_marker}" ||
+        die "toolchain marker checksum mismatch"
+    grep -Fxq "archive_size=${ARM_GNU_SIZE}" "${toolchain_marker}" ||
+        die "toolchain marker size mismatch"
+    for tool in as gcc ld nm objcopy objdump readelf size; do
+        expected="$(tool_hash "${tool}")"
+        [[ -x "${toolchain_dir}/bin/arm-none-eabi-${tool}" ]] ||
+            die "toolchain executable is missing: arm-none-eabi-${tool}"
+        grep -Fxq "tool_sha256.arm-none-eabi-${tool}=${expected}" \
+            "${toolchain_marker}" ||
+            die "toolchain marker digest mismatch: arm-none-eabi-${tool}"
+        [[ "$(sha256_file "${toolchain_dir}/bin/arm-none-eabi-${tool}")" == "${expected}" ]] ||
+            die "toolchain executable was modified after setup: arm-none-eabi-${tool}"
+    done
+    [[ -f "${toolchain_dir}/license.txt" ]] || die "toolchain license is missing"
+    [[ -f "${toolchain_dir}/14.3.rel1-x86_64-arm-none-eabi-manifest.txt" ]] ||
+        die "toolchain upstream manifest is missing"
+}
+
+install_toolchain() {
+    local archive_path="${downloads_dir}/${ARM_GNU_ARCHIVE}"
+    local partial_path="${archive_path}.part"
+    local extract_parent
+
+    prepare_toolchain_archive "${archive_path}" "${partial_path}"
+
+    if [[ -x "${toolchain_dir}/bin/arm-none-eabi-gcc" ]]; then
+        [[ -f "${toolchain_marker}" ]] ||
+            die "refusing pre-existing toolchain without an AymOS install marker: ${toolchain_dir}"
+        validate_toolchain_marker
+        note "Arm GNU Toolchain already installed"
+        return
+    fi
+
+    extract_parent="${tools_dir}/.extract-${ARM_GNU_DIRECTORY}-$$"
+    temporary_paths+=("${extract_parent}")
+    mkdir -p -- "${extract_parent}"
+    note "extracting Arm GNU Toolchain ${ARM_GNU_VERSION}"
+    tar -xJf "${archive_path}" -C "${extract_parent}"
+    [[ -x "${extract_parent}/${ARM_GNU_DIRECTORY}/bin/arm-none-eabi-gcc" ]] ||
+        die "toolchain archive did not contain the expected compiler"
+    [[ ! -e "${toolchain_dir}" ]] ||
+        die "incomplete toolchain directory exists: ${toolchain_dir}"
+    mv -- "${extract_parent}/${ARM_GNU_DIRECTORY}" "${toolchain_dir}"
+    rmdir -- "${extract_parent}"
+    write_toolchain_marker
+}
+
+validate_git_dependency() {
+    local destination="$1"
+    local expected="$2"
+    local name="$3"
+    local actual
+    local status
+
+    [[ -d "${destination}/.git" ]] || die "${name} Git metadata is missing"
+    actual="$(git -C "${destination}" rev-parse HEAD)"
+    [[ "${actual}" == "${expected}" ]] ||
+        die "${name} is at ${actual}, expected ${expected}"
+    status="$(GIT_OPTIONAL_LOCKS=0 git -C "${destination}" status \
+        --porcelain=v1 --untracked-files=all)"
+    [[ -z "${status}" ]] ||
+        die "${name} contains local modifications or untracked files; refusing to overwrite them"
+}
+
+install_git_dependency() {
+    local name="$1"
+    local url="$2"
+    local commit="$3"
+    local destination="${deps_dir}/${name}"
+    local temporary="${deps_dir}/.${name}.fetch-$$"
+    local actual
+
+    temporary_paths+=("${temporary}")
+
+    if [[ -d "${destination}/.git" ]]; then
+        validate_git_dependency "${destination}" "${commit}" "${name}"
+        note "${name} already installed at ${commit}"
+        return
+    fi
+
+    [[ ! -e "${destination}" ]] ||
+        die "non-git dependency path exists: ${destination}"
+    mkdir -p -- "${temporary}"
+    git -C "${temporary}" init --quiet
+    git -C "${temporary}" remote add origin "${url}"
+    note "fetching ${name} at ${commit}"
+    git -C "${temporary}" fetch --quiet --depth 1 origin "${commit}"
+    git -C "${temporary}" -c advice.detachedHead=false checkout --quiet --detach FETCH_HEAD
+    actual="$(git -C "${temporary}" rev-parse HEAD)"
+    [[ "${actual}" == "${commit}" ]] ||
+        die "${name} resolved to ${actual}, expected ${commit}"
+    mv -- "${temporary}" "${destination}"
+}
+
+install_cube_cmsis_core() {
+    local destination="${deps_dir}/stm32cube_f4_core"
+    local temporary="${deps_dir}/.stm32cube_f4_core.fetch-$$"
+    local actual
+    local tag_object
+    local peeled
+
+    temporary_paths+=("${temporary}")
+
+    if [[ -d "${destination}/.git" ]]; then
+        validate_git_dependency "${destination}" "${STM32_CUBE_COMMIT}" \
+            "STM32CubeF4 CMSIS Core"
+        note "STM32CubeF4 CMSIS Core already installed at ${STM32_CUBE_COMMIT}"
+        return
+    fi
+
+    [[ ! -e "${destination}" ]] ||
+        die "non-git dependency path exists: ${destination}"
+    mkdir -p -- "${temporary}"
+    git -C "${temporary}" init --quiet
+    git -C "${temporary}" remote add origin "${STM32_CUBE_URL}"
+    git -C "${temporary}" config remote.origin.promisor true
+    git -C "${temporary}" config remote.origin.partialclonefilter blob:none
+    git -C "${temporary}" sparse-checkout init --no-cone
+    git -C "${temporary}" sparse-checkout set \
+        /Drivers/CMSIS/Core/Include/ /Drivers/CMSIS/LICENSE.txt
+    note "fetching STM32CubeF4 ${STM32_CUBE_TAG} CMSIS Core at ${STM32_CUBE_COMMIT}"
+    git -C "${temporary}" fetch --quiet --depth 1 --filter=blob:none origin \
+        "refs/tags/${STM32_CUBE_TAG}:refs/tags/${STM32_CUBE_TAG}"
+    tag_object="$(git -C "${temporary}" rev-parse "refs/tags/${STM32_CUBE_TAG}")"
+    peeled="$(git -C "${temporary}" rev-parse "refs/tags/${STM32_CUBE_TAG}^{commit}")"
+    [[ "${tag_object}" == "${STM32_CUBE_TAG_OBJECT}" ]] ||
+        die "STM32CubeF4 tag object is ${tag_object}, expected ${STM32_CUBE_TAG_OBJECT}"
+    [[ "${peeled}" == "${STM32_CUBE_COMMIT}" ]] ||
+        die "STM32CubeF4 tag peels to ${peeled}, expected ${STM32_CUBE_COMMIT}"
+    git -C "${temporary}" -c advice.detachedHead=false checkout --quiet --detach \
+        "${STM32_CUBE_COMMIT}"
+    actual="$(git -C "${temporary}" rev-parse HEAD)"
+    [[ "${actual}" == "${STM32_CUBE_COMMIT}" ]] ||
+        die "STM32CubeF4 resolved to ${actual}, expected ${STM32_CUBE_COMMIT}"
+    mv -- "${temporary}" "${destination}"
+}
+
+validate_installation() {
+    local compiler="${toolchain_dir}/bin/arm-none-eabi-gcc"
+    local gcc_version
+
+    [[ -x "${compiler}" ]] || die "compiler installation is incomplete"
+    validate_toolchain_marker
+    gcc_version="$(${compiler} -dumpfullversion)"
+    [[ "${gcc_version}" == 14.3.1 ]] ||
+        die "unexpected GCC version ${gcc_version}; expected 14.3.1"
+
+    validate_git_dependency "${deps_dir}/stm32cube_f4_core" "${STM32_CUBE_COMMIT}" \
+        "STM32CubeF4 CMSIS Core"
+    [[ "$(git -C "${deps_dir}/stm32cube_f4_core" config --get remote.origin.partialclonefilter)" == \
+        "blob:none" ]] || die "STM32CubeF4 checkout is not blob-filtered"
+    grep -Fxq '/Drivers/CMSIS/Core/Include/' \
+        "${deps_dir}/stm32cube_f4_core/.git/info/sparse-checkout" ||
+        die "STM32CubeF4 checkout does not contain the locked sparse Core path"
+    validate_git_dependency "${deps_dir}/cmsis_device_f4" "${STM32_DEVICE_COMMIT}" \
+        "CMSIS device"
+    validate_git_dependency "${deps_dir}/stm32f4xx_hal_driver" "${STM32_HAL_COMMIT}" \
+        "STM32 HAL"
+    [[ -f "${deps_dir}/stm32cube_f4_core/Drivers/CMSIS/Core/Include/core_cm4.h" ]] ||
+        die "CMSIS Core header is missing"
+    [[ -f "${deps_dir}/stm32cube_f4_core/Drivers/CMSIS/Core/Include/cmsis_gcc.h" ]] ||
+        die "CMSIS GCC header is missing"
+    [[ -f "${deps_dir}/stm32cube_f4_core/Drivers/CMSIS/LICENSE.txt" ]] ||
+        die "CMSIS Core license is missing"
+    [[ -f "${deps_dir}/cmsis_device_f4/Include/stm32f401xe.h" ]] ||
+        die "STM32F401 device header is missing"
+    [[ -f "${deps_dir}/cmsis_device_f4/Source/Templates/gcc/startup_stm32f401xe.s" ]] ||
+        die "STM32F401 startup assembly is missing"
+    [[ -f "${deps_dir}/cmsis_device_f4/Source/Templates/system_stm32f4xx.c" ]] ||
+        die "STM32F4 system source is missing"
+    [[ -f "${deps_dir}/cmsis_device_f4/LICENSE.md" ]] ||
+        die "CMSIS device license is missing"
+    [[ -f "${deps_dir}/stm32f4xx_hal_driver/Inc/stm32f4xx_hal.h" ]] ||
+        die "STM32 HAL header is missing"
+    [[ -f "${deps_dir}/stm32f4xx_hal_driver/Src/stm32f4xx_hal.c" ]] ||
+        die "STM32 HAL source is missing"
+    [[ -f "${deps_dir}/stm32f4xx_hal_driver/Src/stm32f4xx_hal_uart.c" ]] ||
+        die "STM32 UART HAL source is missing"
+    [[ -f "${deps_dir}/stm32f4xx_hal_driver/LICENSE.md" ]] ||
+        die "STM32 HAL license is missing"
+
+    local consumed
+    for consumed in \
+        Inc/stm32f4xx_hal.h \
+        Inc/stm32f4xx_hal_cortex.h \
+        Inc/stm32f4xx_hal_dma.h \
+        Inc/stm32f4xx_hal_flash.h \
+        Inc/stm32f4xx_hal_gpio.h \
+        Inc/stm32f4xx_hal_pwr.h \
+        Inc/stm32f4xx_hal_rcc.h \
+        Inc/stm32f4xx_hal_uart.h \
+        Src/stm32f4xx_hal.c \
+        Src/stm32f4xx_hal_cortex.c \
+        Src/stm32f4xx_hal_flash.c \
+        Src/stm32f4xx_hal_gpio.c \
+        Src/stm32f4xx_hal_rcc.c \
+        Src/stm32f4xx_hal_uart.c; do
+        [[ -f "${deps_dir}/stm32f4xx_hal_driver/${consumed}" ]] ||
+            die "build-consumed STM32 HAL file is missing: ${consumed}"
+    done
+
+    note "validated Arm GCC ${gcc_version} and all locked STM32 dependencies"
+}
+
+check_host() {
+    [[ "$(uname -s)" == Linux ]] || die "PR 1 setup currently supports Linux only"
+    [[ "$(uname -m)" == x86_64 ]] || die "PR 1 setup currently supports Linux x86_64 only"
+
+    require_command awk
+    require_command curl
+    require_command file
+    require_command grep
+    require_command git
+    require_command make
+    require_command od
+    require_command sha256sum
+    require_command stat
+    require_command tar
+    require_command xz
+
+    local git_version
+    local curl_version
+    git_version="$(git version | awk '{print $3}')"
+    curl_version="$(curl --version | awk 'NR == 1 {print $2}')"
+    version_at_least "${git_version}" 2 25 ||
+        die "Git ${git_version} is too old; Git 2.25 or newer is required"
+    version_at_least "${curl_version}" 7 61 ||
+        die "curl ${curl_version} is too old; curl 7.61 or newer is required"
+}
+
+main() {
+    local mode="${1:-install}"
+    [[ $# -le 1 ]] || die "usage: setup.sh [--check]"
+    [[ "${mode}" == install || "${mode}" == --check ]] ||
+        die "usage: setup.sh [--check]"
+
+    check_host
+
+    if [[ "${mode}" == --check ]]; then
+        [[ ! -e "${setup_lock_dir}" ]] ||
+            die "dependency setup is currently locked; retry after it completes"
+        validate_installation
+        note "offline dependency integrity check passed"
+        return
+    fi
+
+    mkdir -p -- "${downloads_dir}" "${deps_dir}"
+    if ! mkdir -- "${setup_lock_dir}" 2>/dev/null; then
+        local lock_pid=""
+        [[ -f "${setup_lock_dir}/pid" ]] ||
+            die "setup lock has no PID; fail-safe retry required: ${setup_lock_dir}"
+        lock_pid="$(<"${setup_lock_dir}/pid")"
+        [[ "${lock_pid}" =~ ^[0-9]+$ ]] ||
+            die "setup lock has an invalid PID; inspect without deleting user data: ${setup_lock_dir}"
+        if kill -0 "${lock_pid}" 2>/dev/null; then
+            die "another setup is running as PID ${lock_pid}"
+        fi
+        mv -- "${setup_lock_dir}" "${setup_lock_dir}.stale-${lock_pid}-$$"
+        mkdir -- "${setup_lock_dir}"
+        note "replaced a stale setup lock"
+    fi
+    setup_lock_owned=true
+    printf '%s\n' "$$" > "${setup_lock_dir}/pid"
+    install_toolchain
+    install_cube_cmsis_core
+    install_git_dependency cmsis_device_f4 "${STM32_DEVICE_URL}" "${STM32_DEVICE_COMMIT}"
+    install_git_dependency stm32f4xx_hal_driver "${STM32_HAL_URL}" "${STM32_HAL_COMMIT}"
+    validate_installation
+}
+
+main "$@"

--- a/tools/setup/dependencies.lock
+++ b/tools/setup/dependencies.lock
@@ -1,0 +1,28 @@
+# shellcheck shell=bash
+# Immutable dependency inputs for tools/setup.sh.
+
+ARM_GNU_VERSION="14.3.rel1"
+ARM_GNU_ARCHIVE="arm-gnu-toolchain-14.3.rel1-x86_64-arm-none-eabi.tar.xz"
+ARM_GNU_URL="https://developer.arm.com/-/media/Files/downloads/gnu/14.3.rel1/binrel/${ARM_GNU_ARCHIVE}"
+ARM_GNU_SHA256="8f6903f8ceb084d9227b9ef991490413014d991874a1e34074443c2a72b14dbd"
+ARM_GNU_SIZE="149789432"
+ARM_GNU_GCC_SHA256="510c55cfeed7328ade1eb8cb23808fcce1ba6c52dac8d4ebfe033ae4b2534385"
+ARM_GNU_AS_SHA256="500c3d460643e1961d1de6b5be98c50ceae574d85edce8e3c8c57cf8c35d2fd8"
+ARM_GNU_LD_SHA256="73b48c4930f7b9d9888fb400a46432486596b943d1415101245b735117d97732"
+ARM_GNU_NM_SHA256="d2f338ba59a101e1af6f934b97bffb1419742d610c5bd7c42a086cae4bee9f98"
+ARM_GNU_OBJCOPY_SHA256="0424b422a6c075238c2d4878630e9f111fd0f9320ac34e6f2cd617954042adda"
+ARM_GNU_OBJDUMP_SHA256="29829538419301ed3da5f3148a89e19ea9f9111105fa2ec3e05550f8998a5389"
+ARM_GNU_READELF_SHA256="f797d87877b1f48751803dec8eba9de6f761bcf7810b4868d7f7a3b68fd54cca"
+ARM_GNU_SIZE_SHA256="9aa1623c3874cab906b5cca55212b2f6abaec25fc2b1512e55cf9f1d8217f7cb"
+ARM_GNU_DIRECTORY="arm-gnu-toolchain-14.3.rel1-x86_64-arm-none-eabi"
+
+# These are the component revisions referenced by STM32CubeF4 v1.28.3,
+# peeled commit 94cae6e83f00e276a11957e7833c01ac3d0bd7af.
+STM32_CUBE_URL="https://github.com/STMicroelectronics/STM32CubeF4.git"
+STM32_CUBE_TAG="v1.28.3"
+STM32_CUBE_TAG_OBJECT="ff2098c3b8b1d8373edaa312f80a349f8e7309aa"
+STM32_CUBE_COMMIT="94cae6e83f00e276a11957e7833c01ac3d0bd7af"
+STM32_HAL_URL="https://github.com/STMicroelectronics/stm32f4xx_hal_driver.git"
+STM32_HAL_COMMIT="b6f0ed3829f3829eb358a2e7417d80bba1a42db7"
+STM32_DEVICE_URL="https://github.com/STMicroelectronics/cmsis_device_f4.git"
+STM32_DEVICE_COMMIT="3c77349ce04c8af401454cc51f85ea9a50e34fc1"

--- a/tools/validate_firmware.sh
+++ b/tools/validate_firmware.sh
@@ -1,0 +1,202 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+export LC_ALL=C
+
+die() {
+    printf 'validate: error: %s\n' "$*" >&2
+    exit 1
+}
+
+[[ $# -eq 3 ]] || die "usage: validate_firmware.sh ELF MAP OUTPUT_DIR"
+: "${CROSS_COMPILE:?CROSS_COMPILE must name the project-local tool prefix}"
+
+readonly elf="$1"
+readonly map="$2"
+readonly output_dir="$3"
+readonly readelf="${CROSS_COMPILE}readelf"
+readonly objdump="${CROSS_COMPILE}objdump"
+readonly objcopy="${CROSS_COMPILE}objcopy"
+readonly nm="${CROSS_COMPILE}nm"
+readonly vector_image="${output_dir}/vector-table.bin"
+
+[[ -f "${elf}" ]] || die "ELF not found: ${elf}"
+[[ -f "${map}" ]] || die "map not found: ${map}"
+
+file "${elf}" > "${output_dir}/file.txt"
+"${readelf}" -h "${elf}" > "${output_dir}/readelf-header.txt"
+"${readelf}" -A "${elf}" > "${output_dir}/readelf-attributes.txt"
+"${readelf}" -W -S "${elf}" > "${output_dir}/readelf-sections.txt"
+"${readelf}" -W -l "${elf}" > "${output_dir}/readelf-program-headers.txt"
+"${nm}" -n --defined-only "${elf}" > "${output_dir}/symbols.txt"
+"${objdump}" -h "${elf}" > "${output_dir}/objdump-sections.txt"
+"${objdump}" -d --disassemble=Reset_Handler "${elf}" > \
+    "${output_dir}/reset-handler-disassembly.txt"
+"${objdump}" -d --disassemble=SystemInit "${elf}" > \
+    "${output_dir}/system-init-disassembly.txt"
+"${objcopy}" --dump-section ".isr_vector=${vector_image}" "${elf}" /dev/null
+
+grep -q 'ELF 32-bit LSB executable, ARM' "${output_dir}/file.txt" ||
+    die "file(1) does not identify a 32-bit little-endian ARM executable"
+grep -Eq 'Machine:[[:space:]]+ARM' "${output_dir}/readelf-header.txt" ||
+    die "ELF machine is not ARM"
+grep -Eq 'Flags:.*Version5 EABI.*soft-float ABI' "${output_dir}/readelf-header.txt" ||
+    die "ELF is not EABI5 soft-float"
+grep -Eq 'Tag_CPU_arch:[[:space:]]+v7E-M' "${output_dir}/readelf-attributes.txt" ||
+    die "ELF attributes do not target ARMv7E-M"
+if grep -q 'Tag_ABI_VFP_args' "${output_dir}/readelf-attributes.txt"; then
+    die "hard-float procedure-call attributes are present"
+fi
+
+symbol_address() {
+    local name="$1"
+    local address
+
+    address="$(awk -v symbol="${name}" '$3 == symbol { print $1; exit }' \
+        "${output_dir}/symbols.txt")"
+    [[ -n "${address}" ]] || die "required symbol missing: ${name}"
+    printf '%s\n' "${address}"
+}
+
+hex_value() {
+    local value="${1#0x}"
+    printf '%u\n' "$((16#${value}))"
+}
+
+readonly flash_start=$((0x08000000))
+readonly flash_end=$((0x08080000))
+readonly ram_start=$((0x20000000))
+readonly ram_end=$((0x20018000))
+
+vector_start="$(hex_value "$(symbol_address __vector_table_start__)")"
+vector_end="$(hex_value "$(symbol_address __vector_table_end__)")"
+reset_handler="$(hex_value "$(symbol_address Reset_Handler)")"
+heap_start="$(hex_value "$(symbol_address __aymos_heap_start__)")"
+heap_end="$(hex_value "$(symbol_address __aymos_heap_end__)")"
+newlib_start="$(hex_value "$(symbol_address __newlib_heap_start__)")"
+newlib_end="$(hex_value "$(symbol_address __newlib_heap_end__)")"
+stack_limit="$(hex_value "$(symbol_address __msp_stack_limit__)")"
+stack_top="$(hex_value "$(symbol_address __msp_stack_top__)")"
+estack="$(hex_value "$(symbol_address _estack)")"
+entry_address="$(awk -F: '/Entry point address:/ {gsub(/[[:space:]]/, "", $2); print $2}' \
+    "${output_dir}/readelf-header.txt")"
+[[ -n "${entry_address}" ]] || die "could not parse ELF entry address"
+entry="$(hex_value "${entry_address}")"
+
+((vector_start == flash_start)) || die "vector table is not at flash origin"
+((vector_start % 0x200 == 0)) || die "vector table is not 0x200 aligned"
+((vector_end > vector_start && vector_end <= vector_start + 0x200)) ||
+    die "vector table does not fit its 0x200 alignment slot"
+((reset_handler >= flash_start && reset_handler < flash_end)) ||
+    die "Reset_Handler lies outside flash"
+((entry == (reset_handler | 1))) ||
+    die "ELF entry is not the Thumb Reset_Handler address"
+((heap_start >= ram_start && heap_start <= heap_end)) ||
+    die "AymOS heap start is outside RAM"
+((heap_end == stack_limit)) || die "heap end and MSP stack limit disagree"
+((heap_start % 8 == 0 && heap_end % 8 == 0)) ||
+    die "AymOS heap boundaries are not eight-byte aligned"
+((newlib_start == newlib_end)) || die "newlib heap is not empty"
+((newlib_start == heap_start)) || die "newlib and AymOS linker contract disagrees"
+((stack_top == ram_end && estack == ram_end)) || die "MSP top is not RAM end"
+((stack_limit < stack_top)) || die "MSP reservation is empty"
+
+[[ "$(stat -c '%s' "${vector_image}")" == "$((vector_end - vector_start))" ]] ||
+    die "dumped vector-table size does not match linker symbols"
+read -r vector_msp vector_reset < <(od -An -N8 -t x4 "${vector_image}")
+[[ -n "${vector_msp:-}" && -n "${vector_reset:-}" ]] ||
+    die "could not read initial MSP/reset vector words"
+((16#${vector_msp} == stack_top)) ||
+    die "initial vector MSP does not equal the linked MSP top"
+((16#${vector_reset} == (reset_handler | 1))) ||
+    die "reset vector does not contain the Thumb Reset_Handler address"
+
+mapfile -t system_init_calls < <(
+    grep -nE 'bl[.a-z[:space:]]+.*<SystemInit>' \
+        "${output_dir}/reset-handler-disassembly.txt" || true
+)
+mapfile -t main_calls < <(
+    grep -nE 'bl[.a-z[:space:]]+.*<main>' \
+        "${output_dir}/reset-handler-disassembly.txt" || true
+)
+[[ ${#system_init_calls[@]} -eq 1 ]] ||
+    die "Reset_Handler must contain exactly one parseable SystemInit call"
+[[ ${#main_calls[@]} -eq 1 ]] ||
+    die "Reset_Handler must contain exactly one parseable main call"
+system_init_line="${system_init_calls[0]%%:*}"
+main_line="${main_calls[0]%%:*}"
+[[ "${system_init_line}" =~ ^[0-9]+$ && "${main_line}" =~ ^[0-9]+$ ]] ||
+    die "could not parse Reset_Handler call line numbers"
+((system_init_line < main_line)) ||
+    die "Reset_Handler does not call SystemInit before main"
+
+load_count=0
+flash_origin_load=false
+while read -r offset_hex vma_hex physical_hex file_size_hex memory_size_hex; do
+    load_count=$((load_count + 1))
+    vma="$(hex_value "${vma_hex}")"
+    physical="$(hex_value "${physical_hex}")"
+    file_size="$(hex_value "${file_size_hex}")"
+    memory_size="$(hex_value "${memory_size_hex}")"
+    vma_end=$((vma + memory_size))
+    physical_end=$((physical + file_size))
+
+    ((memory_size >= file_size)) ||
+        die "PT_LOAD ${offset_hex} has MemSiz smaller than FileSiz"
+    ((vma_end >= vma && physical_end >= physical)) ||
+        die "PT_LOAD ${offset_hex} address arithmetic overflowed"
+
+    if ! ((
+        (vma >= flash_start && vma_end <= flash_end) ||
+        (vma >= ram_start && vma_end <= ram_end)
+    )); then
+        die "PT_LOAD ${offset_hex} VMA range lies outside F401RE memory"
+    fi
+
+    if ((file_size > 0)) && ! ((
+        physical >= flash_start && physical_end <= flash_end
+    )); then
+        die "PT_LOAD ${offset_hex} nonempty file payload does not originate in flash"
+    fi
+
+    if ((vma == flash_start && physical == flash_start && file_size > 0)); then
+        flash_origin_load=true
+    fi
+done < <(
+    awk '$1 == "LOAD" { print $2, $3, $4, $5, $6 }' \
+        "${output_dir}/readelf-program-headers.txt"
+)
+((load_count > 0)) || die "ELF has no PT_LOAD program headers"
+[[ "${flash_origin_load}" == true ]] ||
+    die "ELF has no nonempty PT_LOAD whose VMA and LMA start at flash origin"
+
+while read -r section size_hex vma_hex; do
+    section_size="$(hex_value "${size_hex}")"
+    section_start="$(hex_value "${vma_hex}")"
+    section_end=$((section_start + section_size))
+
+    if ((section_size == 0)); then
+        continue
+    fi
+    if ((section_start >= flash_start && section_end <= flash_end)); then
+        continue
+    fi
+    if ((section_start >= ram_start && section_end <= ram_end)); then
+        continue
+    fi
+    die "allocated section ${section} at ${vma_hex}+${size_hex} is outside F401RE memory"
+done < <(
+    awk '
+        $1 ~ /^[0-9]+$/ {
+            name = $2; size = $3; vma = $4;
+            getline flags;
+            if (flags ~ /ALLOC/) print name, size, vma;
+        }
+    ' "${output_dir}/objdump-sections.txt"
+)
+
+grep -q '__aymos_heap_start__' "${map}" || die "map omits AymOS heap symbols"
+grep -q '__newlib_heap_end__' "${map}" || die "map omits newlib heap symbols"
+grep -q '__msp_stack_top__' "${map}" || die "map omits MSP stack symbols"
+
+printf 'validate: F401RE ELF, soft-float ABI, vector table, and memory map are valid\n'


### PR DESCRIPTION
## Problem

AymOS could not build from a clean checkout: the Makefile searched the wrong source directories, referenced an absent F407 linker script, omitted startup/vendor dependencies, selected a hard-float ABI without context preservation, and depended on undocumented global tooling.

## Scope

This is PR 1 of 7 for the AymOS Real-Time Systems Lab. It establishes the canonical NUCLEO-F401RE build foundation and adds the reviewed campaign plan. It intentionally does not link or redesign the legacy kernel.

Base: `main`  
Head: `agent/pr1-reproducible-f401re-build`  
Dependency: none

## Important design decisions

- Pin Arm GNU Toolchain 14.3.rel1 and CubeF4 v1.28.3-compatible CMSIS/HAL sources under ignored project-local directories.
- Verify the official toolchain archive plus every build-facing ARM executable; verify exact/clean Git dependency revisions before any compilation, including parallel Make.
- Reject external ARM tool Make/environment overrides in PR 1 instead of allowing an unvalidated path.
- Use explicit source manifests, Cortex-M4 Thumb-2, and soft-float.
- Use the vendor F401xE startup/vector implementation with a project-owned 512 KiB flash / 96 KiB SRAM linker script.
- Reserve an eight-byte-aligned AymOS heap, disable newlib allocation through an empty linker region and failing `_sbrk`, and retain a separate 4 KiB MSP reservation.
- Keep project warnings fatal and vendor warnings visible.
- Build a minimal HAL boot application that initializes an 84 MHz clock and USART2 without invoking the legacy scheduler.

## Files and modules changed

- `Makefile`: explicit build graph, locked local tools, artifacts, metadata, validation, application selection.
- `tools/setup.sh`, `tools/setup/dependencies.lock`: rootless pinned bootstrap and offline integrity gate.
- `tools/validate_firmware.sh`: ABI, entry/vector, PT_LOAD/LMA, reset-flow, section, heap, and stack validation.
- `apps/boot/`, `bsp/nucleo_f401re/`: minimal application, HAL board support, interrupts, newlib policy, linker script.
- `docs/IMPLEMENTATION_PLAN.md`, `docs/BUILDING.md`, README and legacy-doc status corrections.
- `third_party/README.md`, `.gitignore`: dependency provenance and generated directory policy.

## Exact test commands

```sh
make setup
make setup
make clean
make -j12 firmware
make firmware
make validate
make disassembly
bash -n tools/setup.sh tools/validate_firmware.sh
git diff --check
make firmware APP=unknown       # expected status 2
make flash                      # expected status 2; no programmer invoked
```

Negative integrity tests also introduced a temporary untracked dependency file, temporarily substituted a copied ARM tool, created a missing-PID setup lock, and attempted Make command/environment tool overrides. Each state was restored exactly after the rejection check.

## Test results

- Clean project-local setup and idempotent setup: pass.
- Parallel clean build: pass; offline integrity output completed before the first AS/CC line.
- Project and vendor warnings: zero.
- ELF validation: pass.
- Override/dirty dependency/tampered tool/setup-lock negative paths: rejected before compilation.
- Unknown app and unverified flash paths: expected status 2.
- Committed-state metadata: `git_commit=af0ff4535a56c10b240a8ca2e3234627f16aeea5`, `repository_clean=true`.

Observed artifact evidence:

```text
ELF 32-bit LSB executable, ARM, EABI5, statically linked
CPU: ARMv7E-M / Cortex-M4 / Thumb-2
ABI: soft-float; no VFP argument attributes
FLASH: 5564 B / 512 KiB (1.06%)
RAM reservation: 92 KiB / 96 KiB (includes NOLOAD AymOS heap)
text=5472 data=92 bss=94116
initial vectors: MSP=0x20018000, Reset=0x080001c9
vector table: 0x08000000..0x08000194
AymOS heap: 0x200000b0..0x20017000
MSP reservation: 0x20017000..0x20018000
```

## Manual demonstration

```sh
make setup
make firmware
file build/nucleo_f401re/boot/aymos.elf
make disassembly
```

Artifacts are under `build/nucleo_f401re/boot/`: ELF, binary, map, size, metadata, vector bytes, symbols, program/section headers, and focused reset/SystemInit disassembly.

## Reviewer findings and resolution

Independent bootstrap review initially found a non-blobless Cube fetch, unrecoverable complete partial download, weak installed dependency checks, missing signal/concurrency handling, and incomplete license/version checks. All were fixed and clean-bootstrap retested.

Independent adversarial PR review then found:

- firmware could compile modified dependencies after only existence checks;
- only GCC was hashed;
- `HAL_Init` failure was ignored;
- program load addresses and ELF entry were not validated;
- metadata could go stale;
- locale/prerequisite/docs gaps;
- GNU Make tool overrides could bypass the validated prefix.

The implementation now performs a read-only offline gate before all object recipes, hashes eight build-facing tools, propagates HAL failure, validates entry/reset/PT_LOAD/LMA state, force-regenerates metadata, fixes docs/locale, and rejects tool overrides before recipes. The same reviewer reproduced the negative paths and issued **APPROVE**.

Residual nonblocking risk: GCC private helpers and linked runtime archives are not rehashed after extraction; clean installation is rooted in the verified official archive and the named build-facing executables are rechecked on every build.

## Known limitations

- The legacy scheduler, allocator, SVC/PendSV path, and task runtime are not linked in this PR.
- UART has not yet been observed in Renode; that is the PR 2 gate.
- No physical NUCLEO-F401RE was available. `make flash` is intentionally non-operational and honest.
- RAM size output includes the intentionally reserved NOLOAD custom heap, not initialized image payload.
- Emulator results in later PRs will not establish hardware latency, WCET, or hard real-time guarantees.

## Non-goals

Scheduler redesign, context switching, timing semantics, allocator hardening, structured tracing, host timeline UI, physical flashing validation, and all explicitly deferred synchronization/network/filesystem/POSIX features.

## Judgment

**Ready for final review** as a draft. Do not merge until the owner reviews the stacked campaign order.