### PR TITLE
[PR 2/7] Boot F401RE firmware headlessly in Renode

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,42 @@
+name: AymOS firmware and emulator
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  firmware-and-renode:
+    name: F401RE build and Renode boot
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+
+      - name: Install locked project-local dependencies
+        run: make setup
+
+      - name: Build and validate the F401RE firmware
+        run: make firmware
+
+      - name: Run host tests
+        run: make test
+
+      - name: Run three clean emulator boots
+        run: RENODE_REPEAT=3 make test-emulator
+
+      - name: Retain firmware and emulator diagnostics
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        with:
+          name: aymos-f401re-renode-${{ github.run_id }}
+          if-no-files-found: warn
+          retention-days: 14
+          path: |
+            build/nucleo_f401re/boot/
+            build/renode/

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 /.tools/
 /build/
 /runs/
+__pycache__/
+*.py[cod]

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,11 @@ override LOCKED_TOOL_VARIABLES := \
 	OBJDUMP \
 	READELF \
 	SIZE \
-	NM
+	NM \
+	RENODE_DIR \
+	RENODE \
+	PYTHON_ENV_DIR \
+	PYTHON
 override EXTERNAL_TOOL_VARIABLES := $(strip $(foreach variable,$(LOCKED_TOOL_VARIABLES),\
 	$(if $(filter undefined default,$(origin $(variable))),,\
 		$(variable)[$(origin $(variable))])))
@@ -44,6 +48,10 @@ override OBJDUMP := $(CROSS_COMPILE)objdump
 override READELF := $(CROSS_COMPILE)readelf
 override SIZE := $(CROSS_COMPILE)size
 override NM := $(CROSS_COMPILE)nm
+override RENODE_DIR := $(abspath .tools/renode-1.16.1-dotnet-x86_64)
+override RENODE := $(RENODE_DIR)/renode
+override PYTHON_ENV_DIR := $(abspath .tools/python-venv-renode-1.16.1)
+override PYTHON := $(PYTHON_ENV_DIR)/bin/python3
 
 CMSIS_CORE_DIR := .deps/stm32cube_f4_core/Drivers/CMSIS/Core/Include
 CMSIS_DEVICE_DIR := .deps/cmsis_device_f4
@@ -127,7 +135,9 @@ LDFLAGS := \
 	-Wl,-Map,$(MAP) \
 	-Wl,--cref
 
-.PHONY: firmware setup validate clean clean-build flash disassembly help check-setup FORCE
+.PHONY: firmware setup validate test run test-emulator test-emulator-offline \
+	check-renode-platform clean clean-build clean-emulator flash disassembly \
+	help check-setup FORCE
 
 firmware: check-setup $(ELF) $(BIN) $(SIZE_REPORT) $(BUILD_METADATA) validate
 
@@ -136,6 +146,23 @@ setup:
 
 check-setup:
 	@./tools/setup.sh --check
+
+check-renode-platform:
+	@./tools/renode/check_platform.sh
+
+test: check-setup check-renode-platform
+	@env -u PYTHONHOME -u PYTHONPATH \
+		PYTHONDONTWRITEBYTECODE=1 PYTHONNOUSERSITE=1 \
+		$(PYTHON) -m unittest discover -s tests/renode -p 'test_*.py' -v
+
+run: firmware check-renode-platform
+	@./tools/renode/run.sh
+
+test-emulator: firmware check-renode-platform
+	@./tools/renode/test.sh
+
+test-emulator-offline: firmware check-renode-platform
+	@./tools/renode/test.sh --offline
 
 $(PROJECT_OBJECTS) $(VENDOR_C_OBJECTS) $(VENDOR_ASM_OBJECTS): | check-setup
 
@@ -186,6 +213,8 @@ $(BUILD_METADATA): FORCE $(ELF) tools/setup/dependencies.lock | check-setup
 		printf 'compiler=%s\n' "$$($(CC) -dumpfullversion)"; \
 		printf 'compiler_path=%s\n' '$(CC)'; \
 		printf 'architecture_flags=%s\n' '$(ARCH_FLAGS)'; \
+		printf 'renode=%s\n' '1.16.1'; \
+		printf 'python=%s\n' '3.12.13'; \
 		printf 'stm32cube_f4=%s\n' "$$(git -C .deps/stm32cube_f4_core rev-parse HEAD)"; \
 		printf 'cmsis_device_f4=%s\n' "$$(git -C $(CMSIS_DEVICE_DIR) rev-parse HEAD)"; \
 		printf 'stm32f4xx_hal=%s\n' "$$(git -C $(HAL_DIR) rev-parse HEAD)"; \
@@ -207,17 +236,24 @@ flash: $(BIN)
 clean-build:
 	@rm -rf -- "$(BUILD_DIR)"
 
-clean: clean-build
+clean-emulator:
+	@rm -rf -- "build/renode"
+
+clean: clean-build clean-emulator
 
 help:
 	@printf '%s\n' \
 		'make setup        Install and verify pinned project-local dependencies' \
 		'make firmware     Build and validate the F401RE boot firmware (default)' \
+		'make test         Run host tests for the Renode model and UART validator' \
+		'make run          Boot the exact F401RE ELF headlessly and print UART' \
+		'make test-emulator Run the bounded Renode/Robot UART boot test' \
+		'make test-emulator-offline  Repeat the test in a network namespace' \
 		'make validate     Re-run ELF, map, ABI, and memory validation' \
 		'make disassembly  Generate an annotated disassembly' \
-		'make clean        Remove this board/application build directory' \
+		'make clean        Remove firmware and emulator build artifacts' \
 		'make flash        Build, then stop with the unvalidated hardware notice' \
 		'' \
-		'Selection: BOARD=nucleo_f401re APP=boot (the only PR 1 choices)'
+		'Selection: BOARD=nucleo_f401re APP=boot (the only current choices)'
 
 -include $(DEPENDENCY_FILES)

--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
 # AymOS Real-Time Systems Lab
 
 AymOS is becoming a small, inspectable Cortex-M4 real-time systems lab. The
-current verified slice builds a board-targeted boot image reproducibly. The EDF
-kernel source is retained for the next architecture/lifecycle PR, but is not
-linked into the PR 1 boot application and is not yet claimed to execute safely.
+current verified slice builds a board-targeted boot image reproducibly and
+boots that exact ELF headlessly in pinned Renode. The EDF kernel source is
+retained for the next architecture/lifecycle PR, but is not linked into the
+boot application and is not yet claimed to execute safely.
 
 The canonical target is the STM32F401RE on a NUCLEO-F401RE board:
 
@@ -28,25 +29,40 @@ The canonical target is the STM32F401RE on a NUCLEO-F401RE board:
   and a separate 4 KiB MSP reservation.
 - ELF, binary, map, size, build metadata, attributes, symbols, vector bytes, and
   memory-range validation.
-
-The build has been validated locally. Renode boot and CI are PR 2 scope, so the
-UART banner has not yet been observed in an emulator in this branch.
+- Project-local Renode 1.16.1, CPython 3.12.13, and hash-locked Robot test
+  dependencies; emulator tests do not use global Python packages.
+- A repository-owned, slice-accurate F401RE model with the reset flash alias,
+  Cortex-M4/NVIC/SysTick, 512 KiB flash, 96 KiB SRAM, RCC/PWR, GPIOA, and
+  USART2.
+- A bounded headless boot that emits exactly one `AYMOS READY`, observes an
+  application-local SysTick and SVC smoke handler, and emits the smoke result
+  from thread mode.
+- Host UART-contract tests, a Robot boot test, network-isolated emulator
+  evidence, retained failure artifacts, and a pinned CI workflow definition
+  whose hosted run remains pending.
 
 ## Build
 
-The supported PR 1 host is Linux x86_64. Required bootstrap commands are
-`awk`, `bash`, Git 2.25+, curl 7.61+, `make`, `file`, `grep`, `od`, `sha256sum`,
-`stat`, `tar`, and `xz`. Root access and a global ARM compiler are not used.
+The supported host is Linux x86_64. Required bootstrap commands are
+`awk`, `bash`, Git 2.25+, curl 7.61+, `make`, `cmp`, `env`, `file`, `find`,
+`grep`, `od`, `readlink`, `sha256sum`, `sort`, `stat`, `tar`, `timeout`,
+`xargs`, and `xz`.
+Root access, a global ARM compiler, a global Renode, and a system Python
+environment are not used. The optional network-isolation check also needs host
+`unshare` and `ip`.
 
 ```sh
 make setup
 make firmware
+make test
+make run
+make test-emulator
 ```
 
-`make setup` downloads a 149,789,432-byte Arm archive, checks its locked
-SHA-256 before extraction, and obtains only the locked STM32 source components
-under `.tools/` and `.deps/`. It is safe to rerun and rejects locally modified
-dependencies rather than overwriting them.
+`make setup` downloads locked Arm, Renode, CPython, Python-wheel, and STM32
+inputs under `.tools/` and `.deps/`. Archives and wheels are checked for exact
+byte size and SHA-256 before use. It is safe to rerun and rejects modified
+dependency contents or unexpected files rather than overwriting them.
 
 Every build first runs `tools/setup.sh --check`, an offline/read-only integrity
 gate. Compilation cannot start until all consumed tool hashes, dependency
@@ -84,9 +100,17 @@ Useful commands:
 ```sh
 make validate
 make disassembly
+make test-emulator-offline
+RENODE_REPEAT=10 make test-emulator
 make clean
 make help
 ```
+
+`make run` prints the two validated UART lines and retains its command,
+metadata, raw UART, and emulator log under `build/renode/run/`. Robot test runs
+are retained under `build/renode/test/`, including XML/HTML results and failure
+diagnostics. The raw UART validator is the final acceptance oracle: both lines
+must appear exactly once and in order.
 
 `make flash` deliberately stops after building and prints an unvalidated
 hardware notice. It does not guess which probe/programmer the user has.
@@ -105,14 +129,14 @@ in [the implementation plan](docs/IMPLEMENTATION_PLAN.md). Allocator ownership
 metadata is not hardware memory protection or task isolation.
 
 The API inventory in [docs/API_REFERENCE.md](docs/API_REFERENCE.md) describes
-the legacy source surface, not a verified PR 1 runtime contract.
+the legacy source surface, not a verified runtime contract.
 
 ## Planned campaign
 
 The reviewed sequence is:
 
-1. reproducible F401RE build (this slice);
-2. Renode boot harness and emulator tests;
+1. reproducible F401RE build (implemented and tested);
+2. Renode boot harness and emulator tests (implemented and tested locally);
 3. task lifecycle and Cortex-M context-switch correctness;
 4. explicit timing semantics and deterministic EDF tests;
 5. allocator hardening;
@@ -128,7 +152,8 @@ and are explicitly outside this campaign.
 
 ## Hardware and timing status
 
-No physical NUCLEO-F401RE was available for this build slice. Board flashing and
-serial output therefore remain unvalidated. Future Renode results will prove
-functional event ordering in the model; they will not prove physical interrupt
-latency, worst-case execution time, or hard real-time guarantees.
+No physical NUCLEO-F401RE was available for this slice. Board flashing and
+physical serial output therefore remain unvalidated. The Renode results prove
+functional boot and interrupt/UART behavior in this model; they do not prove
+physical interrupt latency, worst-case execution time, clock accuracy, or hard
+real-time guarantees.

--- a/apps/boot/main.c
+++ b/apps/boot/main.c
@@ -4,13 +4,27 @@
 
 int main(void)
 {
-    static const char banner[] = "AYMOS BOOT F401RE\r\n";
+    static const char banner[] = "AYMOS READY\r\n";
+    static const char smoke[] = "AYMOS SMOKE SYSTICK=1 SVC=1\r\n";
 
     if (board_init() != HAL_OK) {
         board_panic();
     }
 
     if (board_uart_write(banner, sizeof(banner) - 1U) != HAL_OK) {
+        board_panic();
+    }
+
+    while (!board_systick_observed()) {
+        __WFI();
+    }
+
+    board_invoke_svc_smoke();
+    if (!board_svc_observed()) {
+        board_panic();
+    }
+
+    if (board_uart_write(smoke, sizeof(smoke) - 1U) != HAL_OK) {
         board_panic();
     }
 

--- a/bsp/nucleo_f401re/include/board.h
+++ b/bsp/nucleo_f401re/include/board.h
@@ -3,10 +3,14 @@
 
 #include "stm32f4xx_hal.h"
 
+#include <stdbool.h>
 #include <stddef.h>
 
 HAL_StatusTypeDef board_init(void);
 HAL_StatusTypeDef board_uart_write(const char *data, size_t length);
+bool board_systick_observed(void);
+bool board_svc_observed(void);
+void board_invoke_svc_smoke(void);
 void board_panic(void) __attribute__((noreturn));
 
 #endif

--- a/bsp/nucleo_f401re/src/interrupts.c
+++ b/bsp/nucleo_f401re/src/interrupts.c
@@ -1,4 +1,6 @@
-#include "stm32f4xx_hal.h"
+#include "board.h"
+
+#include <stdbool.h>
 
 void NMI_Handler(void);
 void HardFault_Handler(void);
@@ -6,9 +8,13 @@ void MemManage_Handler(void);
 void BusFault_Handler(void);
 void UsageFault_Handler(void);
 void DebugMon_Handler(void);
+void SVC_Handler(void);
 void SysTick_Handler(void);
 
 static void fault_stop(void) __attribute__((noreturn));
+
+static volatile bool systick_observed;
+static volatile bool svc_observed;
 
 void NMI_Handler(void)
 {
@@ -39,9 +45,30 @@ void DebugMon_Handler(void)
 {
 }
 
+void SVC_Handler(void)
+{
+    svc_observed = true;
+}
+
 void SysTick_Handler(void)
 {
     HAL_IncTick();
+    systick_observed = true;
+}
+
+bool board_systick_observed(void)
+{
+    return systick_observed;
+}
+
+bool board_svc_observed(void)
+{
+    return svc_observed;
+}
+
+void board_invoke_svc_smoke(void)
+{
+    __asm volatile("svc #0" ::: "memory");
 }
 
 static void fault_stop(void)

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -3,7 +3,7 @@
 This document describes the public functions provided by AymOS. Each section lists the function prototype, its parameters, the return value and any notes about its usage.
 
 > **Experimental source inventory:** These APIs are present in the legacy
-> kernel/allocator source but are not linked into the PR 1 boot firmware. Their
+> kernel/allocator source but are not linked into the current boot firmware. Their
 > lifecycle, timing, and memory contracts are not yet trustworthy. They become
 > supported only as later implementation-plan gates add architecture and native
 > tests.

--- a/docs/BUILDING.md
+++ b/docs/BUILDING.md
@@ -1,25 +1,28 @@
-# Reproducible F401RE build
+# Reproducible F401RE build and Renode boot
 
 ## Supported environment
 
-PR 1 supports Linux x86_64. The bootstrap requires:
+The verified host path supports Linux x86_64. The bootstrap requires:
 
 - `awk`;
 - Bash;
 - Git 2.25 or newer (sparse checkout and partial clone support);
 - curl 7.61 or newer;
 - GNU Make;
-- `file`, `grep`, `od`, `sha256sum`, `stat`, `tar`, and `xz`; and
+- `cmp`, `env`, `file`, `find`, `grep`, `od`, `readlink`, `sha256sum`, `sort`,
+  `stat`, `tar`, `timeout`, `xargs`, and `xz`; and
 - network access during `make setup`.
 
-No root access, container daemon, global ARM compiler, or global STM32 headers
-are used. The Makefile rejects command-line or environment definitions of
+No root access, container daemon, global ARM compiler, global Renode, system
+Python package, or global STM32 header is used. The Makefile rejects
+command-line or environment definitions of
 `ARM_GNU_DIR`, `CROSS_COMPILE`, `CC`, `OBJCOPY`, `OBJDUMP`, `READELF`, `SIZE`,
-and `NM`; this prevents a caller, including `make -e`, from bypassing the
-locked-tool integrity gate. `BOARD` and `APP` remain ordinary documented build
-selectors. Arm's x86_64 toolchain is built on RHEL 8; hosts older than RHEL 8 or
-Ubuntu 20.04 may lack compatible runtime libraries. Setup executes the compiler
-and reports that failure rather than allowing a later, ambiguous build error.
+`NM`, `RENODE_DIR`, `RENODE`, `PYTHON_ENV_DIR`, and `PYTHON`; this prevents a
+caller, including `make -e`, from bypassing the locked-tool integrity gate.
+`BOARD` and `APP` remain ordinary documented build selectors. Arm's x86_64
+toolchain is built on RHEL 8; hosts older than RHEL 8 or Ubuntu 20.04 may lack
+compatible runtime libraries. Setup executes the tools and reports an
+incompatibility rather than allowing a later, ambiguous error.
 
 Only Linux x86_64 is claimed in this PR. Other host architectures must add and
 validate their own locked tool archive instead of falling back to `PATH`.
@@ -38,7 +41,11 @@ Inputs are declared in `tools/setup/dependencies.lock`:
 - Arm GNU Toolchain 14.3.rel1 for x86_64 `arm-none-eabi`;
 - CMSIS Core from STM32CubeF4 v1.28.3;
 - the STM32F4 CMSIS device commit referenced by that Cube release; and
-- the STM32F4 HAL commit referenced by that Cube release.
+- the STM32F4 HAL commit referenced by that Cube release;
+- Renode 1.16.1's portable .NET x86_64 archive;
+- CPython 3.12.13 from the locked `python-build-standalone` release; and
+- exact wheels and hashes for Robot Framework 6.1, retryfailed 0.2.0, psutil
+  5.9.8, PyYAML 6.0.3, and telnetlib3 2.0.8.
 
 The Arm archive byte size and SHA-256 are checked before extraction. Every
 consumed Arm executable (`gcc`, `as`, `ld`, `nm`, `objcopy`, `objdump`,
@@ -47,6 +54,20 @@ manifest ties them back to the verified archive. STM32 dependencies are checked
 for exact HEAD and for modified/untracked files. Required sources, headers, and
 licenses are validated. The Cube parent is blob-filtered and sparse: projects,
 middleware, and excluded blobs are not downloaded.
+
+Renode, CPython, and the Renode virtual environment have deterministic tree
+manifests covering directory paths, regular-file paths and hashes, and symlink
+paths and target strings. Validation rejects additions, removals, type changes,
+target changes, and special nodes. Only regular `*.pyc` files directly under
+`__pycache__` are excluded as interpreter-generated mutable cache state. All
+locked-Python commands also unset `PYTHONHOME` and `PYTHONPATH`, set
+`PYTHONNOUSERSITE=1`, and disable automatic bytecode writes.
+
+Python wheels are installed offline with `--no-index`, `--only-binary`, and
+`--require-hashes`. Renode upstream names psutil 5.9.3; AymOS intentionally
+uses a locally tested 5.9.8 substitution because 5.9.3 has no CPython 3.12
+wheel and would add an undeclared host C compiler input. This is not described
+as satisfying an exact `==5.9.3` constraint.
 
 Setup uses a repository-local concurrency lock. Interrupted temporary paths use
 unique names and are cleaned on normal exit, SIGINT, and SIGTERM. A complete
@@ -142,6 +163,9 @@ ignored `.tools/` and `.deps/` directories, then run:
 make setup
 make setup
 make firmware
+make test
+make run
+make test-emulator
 ```
 
 The second setup invocation proves idempotence. Do not point cleanup commands at
@@ -158,13 +182,87 @@ The legacy AymOS allocator is not linked into the boot app. Its later hardening
 will consume the already-reserved linker region. PR 1 therefore establishes
 non-overlapping ownership without claiming that the allocator itself is fixed.
 
+## Headless Renode workflow
+
+Run the host-side model and UART validator tests:
+
+```sh
+make test
+```
+
+Boot the exact `build/nucleo_f401re/boot/aymos.elf` for 0.2 seconds of Renode
+virtual time and print the validated raw USART2 stream:
+
+```sh
+make run
+```
+
+Run the Robot integration test:
+
+```sh
+make test-emulator
+```
+
+Robot independently checks that address zero aliases the flash vector, the
+initial MSP word is `0x20018000`, execution reaches both UART lines, and VTOR is
+`0x08000000` after startup. Its UART wait is five seconds, its Robot case limit
+is ten seconds, and the entire host process is bounded by GNU `timeout` with a
+TERM/KILL sequence. The final oracle parses raw UART bytes and requires exactly
+one of each line, in order:
+
+```text
+AYMOS READY\r\n
+AYMOS SMOKE SYSTICK=1 SVC=1\r\n
+```
+
+Every invocation gets a new directory under `build/renode/run/` or
+`build/renode/test/`. It retains command and metadata files, ELF/platform
+hashes, raw and decoded UART, emulator logs, and Robot XML/HTML outputs. On
+failure the scripts return nonzero, print the retained directory, and show the
+tails of available logs plus a raw UART hex dump.
+
+Ten independent boots exercise reset/startup repeatability:
+
+```sh
+RENODE_REPEAT=10 make test-emulator
+```
+
+After setup, the checked runtime inputs contain no URLs. Where the host permits
+unprivileged user/network namespaces, the actual Robot/Renode process can also
+be run with all non-loopback networking removed:
+
+```sh
+make test-emulator-offline
+```
+
+This optional evidence command needs host `unshare` and `ip`; it restores only
+loopback because Robot communicates with Renode through a bounded localhost
+server. The namespace command is itself under the outer timeout.
+
+The repository model intentionally covers only this slice: flash and its reset
+alias, SRAM, Cortex-M4/NVIC/SysTick, flash control, RCC/PWR, RTC/EXTI needed by
+the model, GPIOA, USART2, and the user LED. Renode currently reports visible
+warnings for unmodeled flash cache-enable bits and one RCC reserved bit during
+HAL clock initialization. Those warnings are retained in `emulator.log`; the
+firmware nevertheless completes HAL initialization and both interrupt smokes.
+The model does not represent every F401RE peripheral or register.
+
+The CI workflow runs setup, firmware validation, host tests, and three fresh
+Renode boots on Ubuntu 24.04, then retains build and emulator artifacts even on
+failure. The workflow file is locally reviewed; only a GitHub run can verify
+the hosted-runner environment.
+
 ## Application and hardware status
 
 Startup `SystemInit` configures VTOR before `APP=boot` initializes HAL, an
-84 MHz HSI/PLL clock, PA5, and USART2. The app then emits
-`AYMOS BOOT F401RE` and waits for interrupts. SysTick only advances the HAL
-tick; it does not call legacy scheduler code.
+84 MHz HSI/PLL clock, PA5, and USART2. The app emits `AYMOS READY`, waits until
+the application-local SysTick flag is observed, invokes SVC, checks its
+application-local flag, emits the smoke result from thread mode, and then
+waits for interrupts. Neither handler prints, schedules, switches context, nor
+uses PSP/PendSV. Real kernel SVC/PendSV/PSP evidence remains PR 3 scope.
 
-Renode boot/testing is PR 2. Physical flashing is not validated. `make flash`
-builds the binary, prints that limitation, and exits nonzero rather than running
-an undocumented global programmer.
+Physical flashing is not validated. `make flash` builds the binary, prints that
+limitation, and exits nonzero rather than running an undocumented global
+programmer. Renode execution is functional model evidence only; its virtual or
+host time does not prove hardware timing, interrupt latency, WCET, or hard
+real-time behavior.

--- a/docs/FUNCTIONALITY_OVERVIEW.md
+++ b/docs/FUNCTIONALITY_OVERVIEW.md
@@ -3,8 +3,9 @@
 This document explains the main modules of AymOS and how they work together. It supplements the information in the README.
 
 > **Status:** The kernel and allocator below describe legacy experimental
-> source. PR 1 builds only the F401RE boot application and board support. It
-> does not link or validate task switching, EDF timing, or the allocator.
+> source. The current build links only the F401RE boot application and board
+> support. It does not link or validate task switching, EDF timing, or the
+> allocator.
 
 ## Kernel
 
@@ -43,10 +44,12 @@ Several small test programs under `src/tests` demonstrate the kernel and memory 
 
 These files are manual firmware experiments with separate `main` functions;
 they are not selected by the current build and are not an automated test suite.
-The staged campaign will replace them with native and Renode tests.
+The current slice adds automated host and Renode boot tests. Later PRs replace
+these manual kernel experiments with scheduler, lifecycle, and allocator tests.
 
 ## Next Steps
 
-For the verified build workflow, use `make setup && make firmware` and read
-`docs/BUILDING.md`. Study the legacy exception handlers as prototype code, not
-as a currently verified context-switch implementation.
+For the verified workflow, use `make setup`, `make firmware`, `make test`, and
+`make test-emulator`, then read `docs/BUILDING.md`. Study the legacy exception
+handlers as prototype code, not as a currently verified context-switch
+implementation.

--- a/docs/IMPLEMENTATION_PLAN.md
+++ b/docs/IMPLEMENTATION_PLAN.md
@@ -1,6 +1,8 @@
 # AymOS Real-Time Systems Lab implementation plan
 
-Status: feasibility reviewed; PR 1 implementation authorized
+Status: PR 1 is an unmerged draft whose committed head is the stacked baseline;
+PR 2 is implemented and locally acceptance-tested, with independent re-review
+and the hosted CI run pending
 
 This document defines the first trustworthy vertical slice of AymOS. It is a
 campaign plan, not a claim that the described target behavior exists today.
@@ -24,7 +26,7 @@ corrected to:
 - distinguish reset's address-zero vector fetch from subsequent VTOR-based
   exception dispatch, set VTOR in `SystemInit` before HAL/SysTick, and align the
   complete F401 vector table to its required boundary;
-- keep PR 2's SysTick/SVC smoke application-local (counter/flag handlers with
+- keep PR 2's SysTick/SVC smoke application-local (observed-flag handlers with
   thread-mode reporting), leaving SVC/PendSV/PSP task evidence to PR 3;
 - require exact-one banner validation from raw UART bytes with inner Robot and
   outer host timeouts; and
@@ -32,8 +34,8 @@ corrected to:
   drop-new overflow, an always-observable loss footer, and strict parser
   completeness checks.
 
-These findings are resolved in the plan. Their implementation evidence remains
-owned by the corresponding PR acceptance gates.
+These findings are resolved in the plan. PR 2 now has local implementation
+evidence; later findings remain owned by their corresponding acceptance gates.
 
 ## Product objective and evidence standard
 
@@ -242,17 +244,15 @@ The initial conservative choices are:
   `https://github.com/renode/renode/releases/download/v1.16.1/renode-1.16.1.linux-portable-dotnet.tar.gz`,
   SHA-256
   `00e113cdbd0f5354cf2f64bbe3f5a070d8958409542fca66e45ac97d982938c0`.
-  PR 2 still must verify that this asset executes on the supported clean host.
-  `renode-test` also requires Python packages; those requirements will be
-  installed with exact pins/hashes into the project's local virtual environment
-  rather than resolved from the user's Python environment.
+  PR 2 verifies that this asset executes on the supported host. `renode-test`
+  packages are installed with exact pins/hashes into the project's local
+  virtual environment rather than resolved from the user's Python environment.
 - Python is a project-local runtime, not a system prerequisite beyond setup.
-  PR 2 will pin a CPython 3.12 x86_64 Linux install-only archive from Astral's
-  `python-build-standalone` project by release, URL, and SHA-256 under
-  `.tools/python/`. Both `renode-test` and later host tools will use a virtual
-  environment created by that interpreter with exact, hash-locked
-  requirements. The final archive build and hash are a PR 2 lock-file review
-  item; `python3`, `venv`, and `pip` from `PATH` are not fallback behavior.
+  PR 2 pins CPython 3.12.13's x86_64 Linux install-only archive from Astral's
+  `python-build-standalone` 20260718 release by URL, size, and SHA-256. Both
+  `renode-test` and host validation use a virtual environment created by that
+  interpreter with exact, hash-locked requirements. `python3`, `venv`, and
+  `pip` from `PATH` are not fallback behavior.
 
 Official upstreams are the Arm GNU Toolchain release repository,
 <https://github.com/STMicroelectronics/STM32CubeF4>, its referenced component
@@ -318,13 +318,11 @@ smuggle lifecycle redesign into PR 1 merely to make the link green.
 
 ## Renode integration approach
 
-PR 2 will derive a repository-owned local definition from Renode's pinned
-generic `platforms/cpus/stm32f4.repl` and apply the smallest F401RE overlay
-needed by AymOS. The local copy removes the generic definition's unpinned
-remote `ApplySVD` fetch while preserving all peripheral tags required by
-Renode's STM32 models and tests. The overlay will override flash size to
-`0x80000`, SRAM size to `0x18000`, and SysTick frequency to 84 MHz. The reviewed
-model must map:
+PR 2 derives a repository-owned minimal definition from Renode's pinned generic
+STM32F4 model. It does not inherit the generic definition at runtime, because
+that file contains an unpinned remote `ApplySVD` fetch and many peripherals
+outside this slice. The local definition uses flash size `0x80000`, SRAM size
+`0x18000`, and SysTick frequency 84 MHz. It maps:
 
 - 512 KiB flash at `0x08000000`;
 - 96 KiB SRAM at `0x20000000`;
@@ -347,9 +345,9 @@ interactive/headless demonstration path. `make test-emulator` invokes a Robot
 test with a UART2 terminal tester timeout and wraps the entire Renode process in
 a second host-side timeout. It counts the exact banner bytes in the raw UART
 capture and requires exactly one `AYMOS READY`. After that banner, the guest
-invokes minimal application-local smoke handlers: SysTick increments a counter
-and SVC sets a flag; neither schedules, switches context, or writes UART. Thread
-mode observes the counter/flag and emits the smoke result. The test retains raw
+invokes minimal application-local smoke handlers: SysTick and SVC each set an
+observed flag; neither schedules, switches context, or writes UART. Thread mode
+observes both flags and emits the smoke result. The test retains raw
 UART separately from `emulator.log` on every failure.
 
 Reset occurs before firmware can write VTOR: the Cortex-M reset sequence must
@@ -585,14 +583,15 @@ Acceptance evidence:
 - `make run` loads the exact F401RE ELF and visibly reaches the banner.
 - `make test-emulator` exits successfully only after the raw UART capture
   contains exactly one stable banner and thread mode reports the post-banner
-  application-local SysTick-counter and SVC-flag smoke results. The Robot
+  application-local SysTick-flag and SVC-flag smoke results. The Robot
   terminal tester and outer host process each have an explicit timeout.
 - A missing banner, guest fault, or timeout produces nonzero status and retains
   command, Renode log, and raw UART output as separate artifacts.
 - At least ten clean repeated boots pass to expose startup races.
 - Metadata identifies Renode version, ELF hash, application, and arguments.
-- The model reuses generic `stm32f4.repl` with reviewed F401 sizing/frequency
-  overrides and documents that it is slice-accurate rather than exact silicon.
+- The local model is derived from generic `stm32f4.repl` with reviewed F401
+  sizing/frequency and documents that it is slice-accurate rather than exact
+  silicon; it does not inherit any remote runtime input.
 - The local model has no unpinned `ApplySVD` URL, retains required model tags,
   and runs with network disabled after setup.
 - Renode tests use the pinned project-local CPython and hash-locked virtual
@@ -605,6 +604,15 @@ Acceptance evidence:
   scheduler behavior is faked in host code.
 
 Gate: do not accept PR 3 integration until this boot is reliable.
+
+Local PR 2 evidence (2026-08-01): `make setup`, its offline integrity check,
+`make firmware`, `make test`, `make run`, `make test-emulator`, and
+`make test-emulator-offline` passed. Ten fresh Robot boots also passed with
+`RENODE_REPEAT=10 make test-emulator`. The raw capture was 42 bytes and
+contained the two required lines exactly once. Robot checked the address-zero
+flash alias, `0x20018000` initial MSP word, and `0x08000000` VTOR. Each actual
+emulator process was bounded by an outer TERM/KILL timeout. These local results
+do not substitute for independent review or the hosted CI run.
 
 ### PR 3: task lifecycle and context-switch correctness
 
@@ -839,12 +847,12 @@ only after its own acceptance evidence exists.
 
 | Risk or decision | Current position | Resolution gate |
 |---|---|---|
-| Renode F401RE model completeness | Reuse generic `stm32f4.repl` with `0x80000` flash, `0x18000` SRAM, and 84 MHz SysTick overrides. This is slice-accurate, not exact silicon; do not assume HAL RCC polling works. | Focused PR 2 boot experiment before kernel integration. |
-| Renode generic model fetches an unpinned SVD | Use a reviewed local derivative with remote `ApplySVD` removed and required tags preserved; emulator commands run offline after setup. | Static URL scan plus network-denied PR 2 boot/test. |
+| Renode F401RE model completeness | Resolved for the boot slice: local model uses `0x80000` flash, `0x18000` SRAM, 84 MHz SysTick, and only required peripherals. HAL boots with visible model warnings. This remains slice-accurate, not exact silicon. | Expand only when a later tested workload needs another peripheral. |
+| Renode generic model fetches an unpinned SVD | Resolved for PR 2: the local runtime model has no URLs; static scan and the actual Robot boot passed inside a network namespace after setup. | Keep URL scan and offline evidence in later emulator PRs. |
 | Reset versus VTOR | Reset still needs vectors at address zero before `SystemInit`; later exceptions use the `0x200`-aligned flash table through VTOR. | PR 1 ELF/VTOR checks and PR 2 boot-alias or explicit MSP/PC test. |
-| Exact Arm archive URL/hash | 14.3.rel1 x86_64 `arm-none-eabi` is selected provisionally. | Verify official SHA-256 and run clean setup in PR 1. |
-| CMSIS Core source | Use the Core headers compatible with CubeF4 v1.28.3, fetched minimally. | Compile/include audit and lock review in PR 1. |
-| Existing versus vendor startup | Only one F401xE vector table may link. Vendor startup is preferred unless review validates the local copy. | ELF/vector review in PR 1. |
+| Exact Arm archive URL/hash | Resolved in PR 1: official 14.3.rel1 x86_64 `arm-none-eabi` archive size/hash and consumed tool hashes are locked. | Reverify on any toolchain update. |
+| CMSIS Core source | Resolved in PR 1: compatible Core headers are fetched sparsely from the pinned CubeF4 v1.28.3 commit. | Reverify on a Cube/CMSIS update. |
+| Existing versus vendor startup | Resolved in PR 1: the pinned CMSIS-device F401xE startup is the only linked vector table. | Preserve the single-vector invariant. |
 | HAL versus register-level board setup | HAL is retained initially because the repository already uses it; only required modules are compiled. | PR 2 RCC/UART experiment. |
 | Kernel excluded from PR 1 boot link | Acceptable only if clearly reported and PR 3 links it; prefer inclusion after small compatibility fixes. | PR 1 feasibility review. |
 | Newlib heap | Dynamic newlib allocation is disabled initially so the custom heap is the sole dynamic allocator. | Map and `_sbrk` tests in PR 1; revisit only with demonstrated need. |

--- a/platform/renode/boot.resc
+++ b/platform/renode/boot.resc
@@ -1,0 +1,7 @@
+# Load the exact board-targeted ELF produced by `make firmware`.
+using sysbus
+$bin ?= @build/nucleo_f401re/boot/aymos.elf
+$platform ?= @platform/renode/nucleo_f401re.repl
+mach create "aymos-nucleo-f401re"
+machine LoadPlatformDescription $platform
+sysbus LoadELF $bin

--- a/platform/renode/nucleo_f401re.repl
+++ b/platform/renode/nucleo_f401re.repl
@@ -1,0 +1,80 @@
+// AymOS's deliberately small NUCLEO-F401RE model for Renode 1.16.1.
+//
+// This describes only the hardware used by the current boot slice. It is not a
+// cycle-accurate board model and must not be used to make physical timing or
+// interrupt-latency claims.
+
+flash: Memory.MappedMemory @ {
+        sysbus 0x00000000;
+        sysbus 0x08000000
+    }
+    size: 0x00080000
+
+sram: Memory.MappedMemory @ sysbus 0x20000000
+    size: 0x00018000
+
+flashController: MTD.STM32F4_FlashController @ {
+        sysbus 0x40023C00;
+        sysbus new Bus.BusMultiRegistration { address: 0x1FFFC000; size: 0x100; region: "optionBytes" }
+    }
+    flash: flash
+
+usart2: UART.STM32_UART @ sysbus <0x40004400, +0x100>
+    -> nvic@38
+
+nvic: IRQControllers.NVIC @ sysbus 0xE000E000
+    priorityMask: 0xF0
+    systickFrequency: 84000000
+    IRQ -> cpu@0
+
+cpu: CPU.CortexM @ sysbus
+    cpuType: "cortex-m4"
+    nvic: nvic
+
+pwr: Miscellaneous.STM32_PWR @ sysbus 0x40007000
+
+rtc: Timers.STM32F4_RTC @ sysbus 0x40002800
+    AlarmIRQ -> nvic@41
+
+rcc: Miscellaneous.STM32F4_RCC @ sysbus 0x40023800
+    rtcPeripheral: rtc
+
+exti: IRQControllers.STM32F4_EXTI @ sysbus 0x40013C00
+    numberOfOutputLines: 24
+    [0-4] -> nvic@[6-10]
+    [5-9] -> nvicInput23@[0-4]
+    [10-15] -> nvicInput40@[0-5]
+    [16, 17, 18, 22] -> nvic@[1, 41, 42, 3]
+
+nvicInput23: Miscellaneous.CombinedInput @ none
+    numberOfInputs: 5
+    -> nvic@23
+
+nvicInput40: Miscellaneous.CombinedInput @ none
+    numberOfInputs: 6
+    -> nvic@40
+
+gpioPortA: GPIOPort.STM32_GPIOPort @ sysbus <0x40020000, +0x400>
+    modeResetValue: 0xA8000000
+    outputSpeedResetValue: 0x0C000000
+    pullUpPullDownResetValue: 0x64000000
+    numberOfAFs: 16
+    invertedAFPins: [[5, 3], [7, 1, 3]]
+    [0-15] -> exti@[0-15]
+
+userLed: Miscellaneous.LED @ gpioPortA 5
+
+bitbandPeripherals: Miscellaneous.BitBanding @ sysbus <0x42000000, +0x02000000>
+    peripheralBase: 0x40000000
+
+bitbandSram: Miscellaneous.BitBanding @ sysbus <0x22000000, +0x00200000>
+    peripheralBase: 0x20000000
+
+sysbus:
+    init:
+        // The F4 model does not currently expose every RCC register used by
+        // STM32 HAL. These narrow tags preserve deterministic reset values and
+        // make unsupported accesses visible in emulator.log.
+        Tag <0x40021000, 0x40021003> "UNMODELED_GPIOE_MODER" 0xFFFFFFFF
+        Tag <0x40021004, 0x40021007> "UNMODELED_GPIOE_OTYPER" 0x00000008
+        Tag <0x50000010, 0x5000003f> "UNMODELED_USB_RESET" 0x80000000

--- a/tests/renode/boot.robot
+++ b/tests/renode/boot.robot
@@ -1,0 +1,30 @@
+*** Settings ***
+Test Timeout                      10 seconds
+
+*** Variables ***
+${FIRMWARE_ELF}                   %{AYMOS_FIRMWARE_ELF}
+${BOOT_SCRIPT}                    %{AYMOS_BOOT_SCRIPT}
+${PLATFORM}                       %{AYMOS_PLATFORM}
+${UART_CAPTURE}                   %{AYMOS_UART_CAPTURE}
+
+*** Test Cases ***
+F401RE Firmware Boots And Proves Interrupt Smoke
+    Execute Command               $bin=@${FIRMWARE_ELF}
+    Execute Command               $platform=@${PLATFORM}
+    Execute Command               include @${BOOT_SCRIPT}
+
+    ${alias_vector}=              Execute Command  sysbus ReadDoubleWord 0x00000000
+    ${flash_vector}=              Execute Command  sysbus ReadDoubleWord 0x08000000
+    Should Be Equal As Numbers    ${alias_vector}  0x20018000
+    Should Be Equal As Numbers    ${flash_vector}  0x20018000
+
+    Execute Command               sysbus.usart2 CreateFileBackend @${UART_CAPTURE}
+    Create Terminal Tester        sysbus.usart2  timeout=5
+    Start Emulation
+
+    Wait For Line On Uart         AYMOS READY  timeout=5
+    Wait For Line On Uart         AYMOS SMOKE SYSTICK=1 SVC=1  timeout=5
+
+    Execute Command               pause
+    ${vtor}=                      Execute Command  sysbus ReadDoubleWord 0xE000ED08
+    Should Be Equal As Numbers    ${vtor}  0x08000000

--- a/tests/renode/test_platform.py
+++ b/tests/renode/test_platform.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from pathlib import Path
+import unittest
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
+PLATFORM = REPOSITORY_ROOT / "platform" / "renode" / "nucleo_f401re.repl"
+RUNTIME_INPUTS = (
+    PLATFORM,
+    REPOSITORY_ROOT / "platform" / "renode" / "boot.resc",
+    REPOSITORY_ROOT / "tests" / "renode" / "boot.robot",
+)
+
+
+class PlatformSourceTests(unittest.TestCase):
+    def test_f401_memory_and_cpu_contract_is_explicit(self) -> None:
+        source = PLATFORM.read_text(encoding="utf-8")
+        for required in (
+            "sysbus 0x00000000",
+            "sysbus 0x08000000",
+            "size: 0x00080000",
+            "sysbus 0x20000000",
+            "size: 0x00018000",
+            'cpuType: "cortex-m4"',
+            "systickFrequency: 84000000",
+            "usart2: UART.STM32_UART @ sysbus <0x40004400, +0x100>",
+            "gpioPortA: GPIOPort.STM32_GPIOPort",
+        ):
+            self.assertIn(required, source)
+
+    def test_emulator_runtime_inputs_have_no_network_urls(self) -> None:
+        for path in RUNTIME_INPUTS:
+            source = path.read_text(encoding="utf-8").lower()
+            self.assertNotIn("http://", source, path)
+            self.assertNotIn("https://", source, path)
+            self.assertNotIn("ftp://", source, path)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/renode/test_verify_uart.py
+++ b/tests/renode/test_verify_uart.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import unittest
+
+from tools.renode.verify_uart import MAX_UART_BYTES, UartValidationError, validate_uart
+
+
+class ValidateUartTests(unittest.TestCase):
+    def test_accepts_exact_boot_contract(self) -> None:
+        validate_uart(b"AYMOS READY\r\nAYMOS SMOKE SYSTICK=1 SVC=1\r\n")
+
+    def test_rejects_missing_smoke(self) -> None:
+        with self.assertRaisesRegex(UartValidationError, "observed 0"):
+            validate_uart(b"AYMOS READY\r\n")
+
+    def test_rejects_duplicate_banner(self) -> None:
+        with self.assertRaisesRegex(UartValidationError, "observed 2"):
+            validate_uart(
+                b"AYMOS READY\r\nAYMOS READY\r\n"
+                b"AYMOS SMOKE SYSTICK=1 SVC=1\r\n"
+            )
+
+    def test_rejects_reverse_order(self) -> None:
+        with self.assertRaisesRegex(UartValidationError, "out of order"):
+            validate_uart(
+                b"AYMOS SMOKE SYSTICK=1 SVC=1\r\nAYMOS READY\r\n"
+            )
+
+    def test_rejects_unbounded_capture(self) -> None:
+        with self.assertRaisesRegex(UartValidationError, "limit"):
+            validate_uart(b"x" * (MAX_UART_BYTES + 1))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/third_party/README.md
+++ b/third_party/README.md
@@ -5,7 +5,7 @@ repository. `make setup` installs the immutable inputs declared in
 `tools/setup/dependencies.lock` under ignored `.deps/` and `.tools/`
 directories. The build never searches global include or toolchain paths.
 
-The PR 1 dependency set is:
+The current dependency set is:
 
 | Component | Locked source | License retained after setup |
 |---|---|---|
@@ -13,19 +13,32 @@ The PR 1 dependency set is:
 | CMSIS Core (M) | `STM32CubeF4` v1.28.3, sparse checkout of `Drivers/CMSIS/Core/Include` | `Drivers/CMSIS/LICENSE.txt` (Apache-2.0) |
 | STM32F4 CMSIS device | `cmsis_device_f4` commit referenced by CubeF4 v1.28.3 | Upstream repository license (Apache-2.0) |
 | STM32F4 HAL | `stm32f4xx_hal_driver` commit referenced by CubeF4 v1.28.3 | Upstream repository license (BSD-3-Clause) |
+| Renode | 1.16.1 portable .NET x86_64 release archive | `licenses/renode-license` and bundled component licenses |
+| CPython | 3.12.13 `python-build-standalone` install-only archive, release 20260718 | `lib/python3.12/LICENSE.txt` |
+| Robot test packages | Exact hash-locked wheels listed below | Wheel `.dist-info` license/metadata files |
+
+The Renode Python environment contains Robot Framework 6.1,
+robotframework-retryfailed 0.2.0, psutil 5.9.8, PyYAML 6.0.3, and telnetlib3
+2.0.8. These are the complete runtime set installed with `--no-index` and
+`--require-hashes`. Renode upstream names psutil 5.9.3; AymOS intentionally
+substitutes locally tested 5.9.8 because 5.9.3 has no CPython 3.12 wheel and
+would make a host C compiler an undocumented input. This is not claimed to
+satisfy an exact `==5.9.3` constraint.
 
 Only CMSIS Core headers and the two named STM32 driver repositories are
 fetched. STM32Cube projects, middleware, examples, and click-through/restricted
 components are not downloaded or compiled. The Cube checkout is both sparse and
 blob-filtered, so excluded project/middleware blobs are not transferred.
 
-PR 1 setup supports Linux x86_64 with Git 2.25 or newer and curl 7.61 or
-newer. It also validates `bash`, `file`, `grep`, `make`, `sha256sum`, `stat`,
-`tar`, and `xz`. Arm builds this toolchain on RHEL 8; hosts older than RHEL 8 or
-Ubuntu 20.04 may lack required runtime libraries and are not claimed as
-supported. Setup executes the compiler and fails clearly if its runtime is not
-compatible.
+Setup supports Linux x86_64 with Git 2.25 or newer and curl 7.61 or newer. It
+validates the bootstrap utilities listed in `docs/BUILDING.md`, including the
+commands used for deterministic tree manifests and bounded Renode version
+checks. Arm builds this toolchain on RHEL 8; hosts older than RHEL 8 or Ubuntu
+20.04 may lack required runtime libraries and are not claimed as supported.
+Setup executes the compiler and fails clearly if its runtime is not compatible.
 
-The authoritative URLs, commits, archive byte size, and archive SHA-256 are in
-the lock file. Updating a dependency requires an isolated lock change plus a
-clean setup, build, ELF validation, and license review.
+The authoritative URLs, commits, archive/wheel byte sizes, and SHA-256 values
+are in `tools/setup/dependencies.lock`; the exact Python installation set is in
+`tools/setup/renode-requirements.lock`. Updating a dependency requires an
+isolated lock change plus clean setup, build, host tests, emulator tests, and
+license review.

--- a/tools/renode/check_platform.sh
+++ b/tools/renode/check_platform.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+export LC_ALL=C
+
+readonly script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+readonly repo_root="$(cd -- "${script_dir}/../.." && pwd)"
+
+cd -- "${repo_root}"
+
+readonly runtime_inputs=(
+    platform/renode/nucleo_f401re.repl
+    platform/renode/boot.resc
+    tests/renode/boot.robot
+)
+
+for runtime_input in "${runtime_inputs[@]}"; do
+    [[ -f "${runtime_input}" ]] || {
+        printf 'renode-platform: missing runtime input: %s\n' "${runtime_input}" >&2
+        exit 1
+    }
+done
+
+if grep -Eni '(https?://|ftp://|@https?:)' "${runtime_inputs[@]}"; then
+    printf '%s\n' \
+        'renode-platform: network URL found in an emulator runtime input' >&2
+    exit 1
+fi
+
+printf '%s\n' 'renode-platform: runtime inputs contain no network URLs'

--- a/tools/renode/robot_once.sh
+++ b/tools/renode/robot_once.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+export LC_ALL=C
+
+readonly script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+readonly repo_root="$(cd -- "${script_dir}/../.." && pwd)"
+readonly renode_dir="${repo_root}/.tools/renode-1.16.1-dotnet-x86_64"
+readonly python_venv="${repo_root}/.tools/python-venv-renode-1.16.1"
+
+if [[ "${AYMOS_NETWORK_ISOLATED:-0}" == 1 ]]; then
+    [[ -x "${AYMOS_IP_COMMAND:-}" ]] || {
+        printf '%s\n' 'renode-test: network isolation requires an explicit ip command' >&2
+        exit 2
+    }
+    "${AYMOS_IP_COMMAND}" link set lo up
+fi
+
+mkdir -p -- "${AYMOS_ROBOT_RESULTS}" "${AYMOS_TEST_HOME}" \
+    "${AYMOS_TEST_XDG_CONFIG_HOME}"
+
+cd -- "${repo_root}"
+exec env -u PYTHONHOME -u PYTHONPATH \
+    PATH="${python_venv}/bin:${PATH}" \
+    PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONNOUSERSITE=1 \
+    RENODE_CI_MODE=YES \
+    HOME="${AYMOS_TEST_HOME}" \
+    XDG_CONFIG_HOME="${AYMOS_TEST_XDG_CONFIG_HOME}" \
+    "${renode_dir}/renode-test" \
+    --stop-on-error \
+    --save-logs always \
+    --keep-renode-output \
+    --test-timeout 10s \
+    --cleanup-timeout 3 \
+    --kill-timeout 2 \
+    -r "${AYMOS_ROBOT_RESULTS}" \
+    tests/renode/boot.robot

--- a/tools/renode/run.sh
+++ b/tools/renode/run.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+export LC_ALL=C
+
+readonly script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+readonly repo_root="$(cd -- "${script_dir}/../.." && pwd)"
+readonly renode="${repo_root}/.tools/renode-1.16.1-dotnet-x86_64/renode"
+readonly python="${repo_root}/.tools/python-venv-renode-1.16.1/bin/python3"
+readonly elf="${repo_root}/build/nucleo_f401re/boot/aymos.elf"
+readonly boot_script="${repo_root}/platform/renode/boot.resc"
+readonly platform="${repo_root}/platform/renode/nucleo_f401re.repl"
+readonly host_timeout="${AYMOS_RENODE_HOST_TIMEOUT:-30}"
+readonly virtual_duration="${AYMOS_RENODE_VIRTUAL_DURATION:-0.2}"
+readonly run_id="$(date -u +%Y%m%dT%H%M%SZ)-$$"
+readonly output_dir="${AYMOS_RENODE_OUTPUT_DIR:-${repo_root}/build/renode/run/${run_id}}"
+readonly uart_capture="${output_dir}/uart.bin"
+readonly emulator_log="${output_dir}/emulator.log"
+readonly monitor_command="\$bin=@${elf}; \$platform=@${platform}; include @${boot_script}; sysbus.usart2 CreateFileBackend @${uart_capture}; emulation RunFor \"${virtual_duration}\"; quit"
+
+validate_inputs() {
+    [[ "${host_timeout}" =~ ^[0-9]+$ ]] && ((host_timeout >= 5 && host_timeout <= 300)) || {
+        printf 'renode-run: invalid AYMOS_RENODE_HOST_TIMEOUT: %s\n' \
+            "${host_timeout}" >&2
+        exit 2
+    }
+    [[ "${virtual_duration}" =~ ^[0-9]+([.][0-9]+)?$ ]] || {
+        printf 'renode-run: invalid AYMOS_RENODE_VIRTUAL_DURATION: %s\n' \
+            "${virtual_duration}" >&2
+        exit 2
+    }
+    for required in "${renode}" "${python}" "${elf}" "${boot_script}" "${platform}"; do
+        [[ -f "${required}" ]] || {
+            printf 'renode-run: missing required input: %s\n' "${required}" >&2
+            exit 2
+        }
+    done
+    [[ "${repo_root}" != *[$'\n\r\t ']* ]] || {
+        printf '%s\n' \
+            'renode-run: the repository path may not contain whitespace' >&2
+        exit 2
+    }
+}
+
+show_diagnostics() {
+    local status=$?
+
+    trap - EXIT
+    if ((status != 0)); then
+        printf 'renode-run: failed with status %d; artifacts: %s\n' \
+            "${status}" "${output_dir}" >&2
+        if [[ -f "${emulator_log}" ]]; then
+            printf '%s\n' '--- emulator.log (last 200 lines) ---' >&2
+            tail -n 200 "${emulator_log}" >&2
+        fi
+        if [[ -f "${output_dir}/uart-validation.log" ]]; then
+            printf '%s\n' '--- uart-validation.log ---' >&2
+            cat "${output_dir}/uart-validation.log" >&2
+        fi
+        if [[ -f "${uart_capture}" ]]; then
+            printf '%s\n' '--- uart.bin (hex/ASCII) ---' >&2
+            od -An -tx1c "${uart_capture}" >&2
+        fi
+    fi
+    exit "${status}"
+}
+
+validate_inputs
+mkdir -p -- "$(dirname -- "${output_dir}")"
+mkdir -- "${output_dir}"
+mkdir -- "${output_dir}/home" "${output_dir}/xdg"
+trap show_diagnostics EXIT
+
+renode_build="$(
+    timeout --signal=TERM --kill-after=2s 10s \
+        env HOME="${output_dir}/home" XDG_CONFIG_HOME="${output_dir}/xdg" \
+        "${renode}" --version
+)" || {
+    printf '%s\n' 'renode-run: Renode version command failed or timed out' >&2
+    exit 1
+}
+renode_build="$(printf '%s' "${renode_build}" | tr '\n' ' ' | sed 's/[[:space:]]*$//')"
+
+{
+    printf 'schema=1\n'
+    printf 'board=nucleo_f401re\n'
+    printf 'app=boot\n'
+    printf 'git_commit=%s\n' "$(git -C "${repo_root}" rev-parse HEAD)"
+    printf 'repository_clean=%s\n' \
+        "$(test -z "$(git -C "${repo_root}" status --porcelain)" && printf true || printf false)"
+    printf 'firmware=%s\n' "${elf}"
+    printf 'firmware_sha256=%s\n' "$(sha256sum "${elf}" | awk '{print $1}')"
+    printf 'platform=%s\n' "${platform}"
+    printf 'platform_sha256=%s\n' "$(sha256sum "${platform}" | awk '{print $1}')"
+    printf 'renode_version=1.16.1\n'
+    printf 'renode_build=%s\n' "${renode_build}"
+    printf 'command_file=command.txt\n'
+    printf 'emulator_arguments=--console --disable-gui --plain -e <monitor_command>\n'
+    printf 'host_timeout_seconds=%s\n' "${host_timeout}"
+    printf 'virtual_duration_seconds=%s\n' "${virtual_duration}"
+    printf 'timing_claims=none_emulator_functional_test_only\n'
+} > "${output_dir}/metadata.txt"
+
+printf '%q ' \
+    timeout --signal=TERM --kill-after=5s "${host_timeout}s" \
+    env "HOME=${output_dir}/home" "XDG_CONFIG_HOME=${output_dir}/xdg" \
+    "${renode}" --console --disable-gui --plain \
+    -e "${monitor_command}" \
+    > "${output_dir}/command.txt"
+printf '> %q 2>&1\n' "${emulator_log}" >> "${output_dir}/command.txt"
+
+timeout --signal=TERM --kill-after=5s "${host_timeout}s" \
+    env HOME="${output_dir}/home" XDG_CONFIG_HOME="${output_dir}/xdg" \
+    "${renode}" --console --disable-gui --plain \
+    -e "${monitor_command}" \
+    > "${emulator_log}" 2>&1
+
+if grep -Eq "There was an error executing command|Error E[0-9]+:" \
+    "${emulator_log}"; then
+    printf '%s\n' 'renode-run: Renode reported a monitor command error' >&2
+    exit 1
+fi
+
+set +e
+env -u PYTHONHOME -u PYTHONPATH \
+    PYTHONDONTWRITEBYTECODE=1 PYTHONNOUSERSITE=1 \
+    "${python}" "${script_dir}/verify_uart.py" "${uart_capture}" \
+    > "${output_dir}/uart.txt" 2> "${output_dir}/uart-validation.log"
+status=$?
+set -e
+((status == 0)) || exit "${status}"
+cat "${output_dir}/uart.txt"
+
+trap - EXIT
+printf 'renode-run: artifacts: %s\n' "${output_dir}"

--- a/tools/renode/test.sh
+++ b/tools/renode/test.sh
@@ -1,0 +1,177 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+export LC_ALL=C
+
+readonly script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+readonly repo_root="$(cd -- "${script_dir}/../.." && pwd)"
+readonly python="${repo_root}/.tools/python-venv-renode-1.16.1/bin/python3"
+readonly renode="${repo_root}/.tools/renode-1.16.1-dotnet-x86_64/renode"
+readonly elf="${repo_root}/build/nucleo_f401re/boot/aymos.elf"
+readonly boot_script="${repo_root}/platform/renode/boot.resc"
+readonly platform="${repo_root}/platform/renode/nucleo_f401re.repl"
+readonly repeat="${RENODE_REPEAT:-1}"
+readonly host_timeout="${AYMOS_RENODE_HOST_TIMEOUT:-30}"
+readonly test_id="$(date -u +%Y%m%dT%H%M%SZ)-$$"
+readonly output_root="${AYMOS_RENODE_TEST_OUTPUT_DIR:-${repo_root}/build/renode/test/${test_id}}"
+offline=false
+
+usage() {
+    printf '%s\n' 'usage: tools/renode/test.sh [--offline]' >&2
+    exit 2
+}
+
+if (($# > 1)); then
+    usage
+elif (($# == 1)); then
+    [[ "$1" == --offline ]] || usage
+    offline=true
+fi
+
+[[ "${repeat}" =~ ^[0-9]+$ ]] && ((repeat >= 1 && repeat <= 100)) || {
+    printf 'renode-test: invalid RENODE_REPEAT: %s\n' "${repeat}" >&2
+    exit 2
+}
+[[ "${host_timeout}" =~ ^[0-9]+$ ]] && ((host_timeout >= 5 && host_timeout <= 300)) || {
+    printf 'renode-test: invalid AYMOS_RENODE_HOST_TIMEOUT: %s\n' \
+        "${host_timeout}" >&2
+    exit 2
+}
+[[ "${repo_root}" != *[$'\n\r\t ']* ]] || {
+    printf '%s\n' 'renode-test: the repository path may not contain whitespace' >&2
+    exit 2
+}
+for required in "${python}" "${renode}" "${elf}" "${boot_script}" "${platform}"; do
+    [[ -f "${required}" ]] || {
+        printf 'renode-test: missing required input: %s\n' "${required}" >&2
+        exit 2
+    }
+done
+
+"${script_dir}/check_platform.sh"
+
+unshare_command=""
+ip_command=""
+if [[ "${offline}" == true ]]; then
+    unshare_command="$(command -v unshare || true)"
+    ip_command="$(command -v ip || true)"
+    [[ -x "${unshare_command}" && -x "${ip_command}" ]] || {
+        printf '%s\n' \
+            'renode-test: --offline requires host unshare and ip commands' >&2
+        exit 2
+    }
+fi
+
+mkdir -p -- "$(dirname -- "${output_root}")"
+mkdir -- "${output_root}"
+
+overall_status=0
+for ((attempt = 1; attempt <= repeat; attempt++)); do
+    attempt_dir="${output_root}/attempt-${attempt}"
+    mkdir -- "${attempt_dir}"
+    mkdir -- "${attempt_dir}/home" "${attempt_dir}/xdg"
+    uart_capture="${attempt_dir}/uart.bin"
+    robot_results="${attempt_dir}/robot"
+    test_log="${attempt_dir}/test.log"
+    renode_build="$(
+        timeout --signal=TERM --kill-after=2s 10s \
+            env HOME="${attempt_dir}/home" \
+            XDG_CONFIG_HOME="${attempt_dir}/xdg" \
+            "${renode}" --version
+    )" || {
+        printf 'renode-test: Renode version command failed or timed out; artifacts: %s\n' \
+            "${attempt_dir}" >&2
+        exit 1
+    }
+    renode_build="$(printf '%s' "${renode_build}" | tr '\n' ' ' | sed 's/[[:space:]]*$//')"
+
+    {
+        printf 'schema=1\n'
+        printf 'board=nucleo_f401re\n'
+        printf 'app=boot\n'
+        printf 'attempt=%s\n' "${attempt}"
+        printf 'repeat=%s\n' "${repeat}"
+        printf 'network_isolated=%s\n' "${offline}"
+        printf 'git_commit=%s\n' "$(git -C "${repo_root}" rev-parse HEAD)"
+        printf 'repository_clean=%s\n' \
+            "$(test -z "$(git -C "${repo_root}" status --porcelain)" && printf true || printf false)"
+        printf 'firmware_sha256=%s\n' "$(sha256sum "${elf}" | awk '{print $1}')"
+        printf 'platform_sha256=%s\n' "$(sha256sum "${platform}" | awk '{print $1}')"
+        printf 'renode_version=1.16.1\n'
+        printf 'renode_build=%s\n' "${renode_build}"
+        printf 'command_file=command.txt\n'
+        printf 'robot_suite=tests/renode/boot.robot\n'
+        printf 'host_timeout_seconds=%s\n' "${host_timeout}"
+        printf 'timing_claims=none_emulator_functional_test_only\n'
+    } > "${attempt_dir}/metadata.txt"
+
+    runner_environment=(
+        "AYMOS_FIRMWARE_ELF=${elf}"
+        "AYMOS_BOOT_SCRIPT=${boot_script}"
+        "AYMOS_PLATFORM=${platform}"
+        "AYMOS_UART_CAPTURE=${uart_capture}"
+        "AYMOS_ROBOT_RESULTS=${robot_results}"
+        "AYMOS_TEST_HOME=${attempt_dir}/home"
+        "AYMOS_TEST_XDG_CONFIG_HOME=${attempt_dir}/xdg"
+    )
+    runner=(env "${runner_environment[@]}" "${script_dir}/robot_once.sh")
+    if [[ "${offline}" == true ]]; then
+        runner=(
+            "${unshare_command}" --user --map-root-user --net
+            env "AYMOS_NETWORK_ISOLATED=1" "AYMOS_IP_COMMAND=${ip_command}"
+            "${runner_environment[@]}" "${script_dir}/robot_once.sh"
+        )
+    fi
+
+    printf '%q ' timeout --signal=TERM --kill-after=5s "${host_timeout}s" \
+        "${runner[@]}" > "${attempt_dir}/command.txt"
+    printf '> %q 2>&1\n' "${test_log}" >> "${attempt_dir}/command.txt"
+
+    set +e
+    timeout --signal=TERM --kill-after=5s "${host_timeout}s" \
+        "${runner[@]}" > "${test_log}" 2>&1
+    status=$?
+    set -e
+
+    renode_stdout="$(find "${robot_results}/logs" -maxdepth 1 \
+        -type f -name '*.renode_stdout.log' -print -quit 2>/dev/null || true)"
+    if [[ -n "${renode_stdout}" ]]; then
+        cp -- "${renode_stdout}" "${attempt_dir}/emulator.log"
+    fi
+
+    if ((status == 0)); then
+        set +e
+        env -u PYTHONHOME -u PYTHONPATH \
+            PYTHONDONTWRITEBYTECODE=1 PYTHONNOUSERSITE=1 \
+            "${python}" "${script_dir}/verify_uart.py" "${uart_capture}" \
+            > "${attempt_dir}/uart.txt" 2> "${attempt_dir}/uart-validation.log"
+        status=$?
+        set -e
+    fi
+
+    if ((status != 0)); then
+        overall_status="${status}"
+        printf 'renode-test: attempt %d failed with status %d; artifacts: %s\n' \
+            "${attempt}" "${status}" "${attempt_dir}" >&2
+        printf '%s\n' '--- test.log (last 200 lines) ---' >&2
+        tail -n 200 "${test_log}" >&2 || true
+        if [[ -f "${attempt_dir}/emulator.log" ]]; then
+            printf '%s\n' '--- emulator.log (last 200 lines) ---' >&2
+            tail -n 200 "${attempt_dir}/emulator.log" >&2 || true
+        fi
+        if [[ -f "${attempt_dir}/uart-validation.log" ]]; then
+            printf '%s\n' '--- uart-validation.log ---' >&2
+            cat "${attempt_dir}/uart-validation.log" >&2 || true
+        fi
+        if [[ -f "${uart_capture}" ]]; then
+            printf '%s\n' '--- uart.bin (hex/ASCII) ---' >&2
+            od -An -tx1c "${uart_capture}" >&2 || true
+        fi
+        break
+    fi
+
+    printf 'renode-test: attempt %d/%d passed\n' "${attempt}" "${repeat}"
+done
+
+printf 'renode-test: artifacts: %s\n' "${output_root}"
+exit "${overall_status}"

--- a/tools/renode/verify_uart.py
+++ b/tools/renode/verify_uart.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+"""Validate the bounded UART contract for the PR 2 boot smoke."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+MAX_UART_BYTES = 1024 * 1024
+REQUIRED_LINES = (
+    b"AYMOS READY\r\n",
+    b"AYMOS SMOKE SYSTICK=1 SVC=1\r\n",
+)
+
+
+class UartValidationError(ValueError):
+    """The captured UART stream did not satisfy the boot contract."""
+
+
+def validate_uart(data: bytes) -> None:
+    if len(data) > MAX_UART_BYTES:
+        raise UartValidationError(
+            f"UART capture is {len(data)} bytes; limit is {MAX_UART_BYTES}"
+        )
+
+    previous_offset = -1
+    for required in REQUIRED_LINES:
+        count = data.count(required)
+        if count != 1:
+            line = required.rstrip().decode("ascii")
+            raise UartValidationError(
+                f"expected exactly one {line!r} line, observed {count}"
+            )
+        offset = data.index(required)
+        if offset <= previous_offset:
+            raise UartValidationError("required UART lines are out of order")
+        previous_offset = offset
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="validate AymOS's raw PR 2 UART boot capture"
+    )
+    parser.add_argument("capture", type=Path)
+    args = parser.parse_args()
+
+    try:
+        data = args.capture.read_bytes()
+        validate_uart(data)
+    except (OSError, UartValidationError) as error:
+        parser.error(str(error))
+
+    print(data.decode("ascii", errors="backslashreplace"), end="")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/setup.sh
+++ b/tools/setup.sh
@@ -16,9 +16,21 @@ readonly deps_dir="${repo_root}/.deps"
 readonly downloads_dir="${tools_dir}/downloads"
 readonly toolchain_dir="${tools_dir}/${ARM_GNU_DIRECTORY}"
 readonly toolchain_marker="${toolchain_dir}/.aymos-install-manifest"
+readonly renode_dir="${tools_dir}/${RENODE_DIRECTORY}"
+readonly python_dir="${tools_dir}/${PYTHON_DIRECTORY}"
+readonly python_venv_dir="${tools_dir}/${PYTHON_VENV_DIRECTORY}"
+readonly wheels_dir="${downloads_dir}/python-wheels"
+readonly python_requirements="${script_dir}/setup/renode-requirements.lock"
+readonly tree_manifest_name=".aymos-tree-manifest"
+readonly legacy_tree_file_list_name=".aymos-file-list-sha256"
 readonly setup_lock_dir="${tools_dir}/setup.lock"
+readonly -a locked_python_env=(
+    env -u PYTHONHOME -u PYTHONPATH
+    PYTHONDONTWRITEBYTECODE=1 PYTHONNOUSERSITE=1
+)
 temporary_paths=()
 setup_lock_owned=false
+python_venv_owned=false
 
 die() {
     printf 'setup: error: %s\n' "$*" >&2
@@ -27,6 +39,10 @@ die() {
 
 note() {
     printf 'setup: %s\n' "$*"
+}
+
+renode_version_output() {
+    timeout --signal=TERM --kill-after=2s 10s "$1" --version
 }
 
 cleanup_temporary_paths() {
@@ -47,6 +63,10 @@ cleanup_temporary_paths() {
     if [[ "${setup_lock_owned}" == true && -d "${setup_lock_dir}" ]]; then
         rm -f -- "${setup_lock_dir}/pid"
         rmdir -- "${setup_lock_dir}"
+    fi
+
+    if [[ "${python_venv_owned}" == true && -d "${python_venv_dir}" ]]; then
+        rm -rf -- "${python_venv_dir}"
     fi
 }
 
@@ -131,6 +151,105 @@ prepare_toolchain_archive() {
         die "downloaded toolchain mismatch: expected ${ARM_GNU_SIZE}/${ARM_GNU_SHA256}, got ${size}/${digest}"
     fi
     mv -- "${partial_path}" "${archive_path}"
+}
+
+prepare_locked_download() {
+    local label="$1"
+    local url="$2"
+    local expected="$3"
+    local expected_size="$4"
+    local archive_path="$5"
+    local partial_path="${archive_path}.part"
+    local size
+    local digest
+
+    if archive_matches "${archive_path}" "${expected}" "${expected_size}"; then
+        return
+    elif [[ -f "${archive_path}" ]]; then
+        quarantine_file "${archive_path}" archive
+    fi
+
+    if [[ -f "${partial_path}" ]]; then
+        size="$(stat -c '%s' "${partial_path}")"
+        if ((size == expected_size)); then
+            if archive_matches "${partial_path}" "${expected}" "${expected_size}"; then
+                mv -- "${partial_path}" "${archive_path}"
+                return
+            fi
+            quarantine_file "${partial_path}" checksum
+        elif ((size > expected_size)); then
+            quarantine_file "${partial_path}" oversized
+        fi
+    fi
+
+    note "downloading ${label}"
+    curl --fail --location --retry 3 --silent --show-error --continue-at - \
+        --output "${partial_path}" "${url}"
+    if ! archive_matches "${partial_path}" "${expected}" "${expected_size}"; then
+        size="$(stat -c '%s' "${partial_path}")"
+        digest="$(sha256_file "${partial_path}")"
+        quarantine_file "${partial_path}" downloaded
+        die "download mismatch for ${label}: expected ${expected_size}/${expected}, got ${size}/${digest}"
+    fi
+    mv -- "${partial_path}" "${archive_path}"
+}
+
+emit_tree_manifest() {
+    local directory="$1"
+    local special_node_present
+
+    (
+        cd -- "${directory}"
+        special_node_present="$(
+            find . ! -type d ! -type f ! -type l -printf x -quit
+        )" || return 1
+        if [[ -n "${special_node_present}" ]]; then
+            printf 'setup: unsupported special filesystem node in dependency: %s\n' \
+                "${directory}" >&2
+            return 1
+        fi
+
+        printf 'AYMOS_TREE_V3\0DIRECTORIES\0'
+        find . -type d -print0 | sort -z || return 1
+
+        printf 'FILES\0'
+        # Bytecode is interpreter-generated mutable cache state. Because the
+        # -type f filter comes first, only regular *.pyc files directly below
+        # __pycache__ are ignored; matching symlinks remain in the next section.
+        # Hash regular files in ARG_MAX-sized batches rather than forking once
+        # per file. sha256sum -z keeps arbitrary path bytes unambiguous.
+        find . -type f ! -path "./${tree_manifest_name}" \
+            ! \( -path '*/__pycache__/*.pyc' \
+                ! -path '*/__pycache__/*/*.pyc' \) -print0 | sort -z | \
+            xargs -0 -r sha256sum -z -- || return 1
+
+        printf 'SYMLINKS\0'
+        # NUL cannot occur in a path or symlink target. The record prefix and
+        # separator make the path/target association explicit; paths are also
+        # present directly in every sorted record.
+        find . -type l -printf 'L\034%p\034%l\0' | sort -z
+    )
+}
+
+write_tree_manifest() {
+    local directory="$1"
+    local manifest="${directory}/${tree_manifest_name}"
+
+    # Remove the superseded regular-file-only marker when migrating a local
+    # development install. Clean installs never contain it.
+    rm -f -- "${directory}/${legacy_tree_file_list_name}"
+    emit_tree_manifest "${directory}" > "${manifest}"
+}
+
+validate_tree_manifest() {
+    local directory="$1"
+    local label="$2"
+    local manifest="${directory}/${tree_manifest_name}"
+
+    [[ -f "${manifest}" && ! -L "${manifest}" ]] ||
+        die "${label} install manifest is missing or is not a regular file"
+    emit_tree_manifest "${directory}" | cmp --silent "${manifest}" - ||
+        die "${label} filesystem tree was modified after setup"
 }
 
 tool_hash() {
@@ -222,6 +341,158 @@ install_toolchain() {
     mv -- "${extract_parent}/${ARM_GNU_DIRECTORY}" "${toolchain_dir}"
     rmdir -- "${extract_parent}"
     write_toolchain_marker
+}
+
+install_renode() {
+    local archive_path="${downloads_dir}/${RENODE_ARCHIVE}"
+    local extract_parent
+    local version_output
+
+    prepare_locked_download "Renode ${RENODE_VERSION}" "${RENODE_URL}" \
+        "${RENODE_SHA256}" "${RENODE_SIZE}" "${archive_path}"
+
+    if [[ -x "${renode_dir}/renode" ]]; then
+        validate_tree_manifest "${renode_dir}" "Renode"
+        version_output="$(renode_version_output "${renode_dir}/renode")" ||
+            die "installed Renode version command failed or timed out"
+        [[ "${version_output}" == *"Renode v${RENODE_VERSION}."* ]] ||
+            die "unexpected installed Renode version"
+        note "Renode ${RENODE_VERSION} already installed"
+        return
+    fi
+
+    [[ ! -e "${renode_dir}" ]] ||
+        die "incomplete Renode directory exists: ${renode_dir}"
+    extract_parent="${tools_dir}/.extract-${RENODE_DIRECTORY}-$$"
+    temporary_paths+=("${extract_parent}")
+    mkdir -p -- "${extract_parent}"
+    note "extracting Renode ${RENODE_VERSION}"
+    tar -xzf "${archive_path}" -C "${extract_parent}"
+    [[ -x "${extract_parent}/${RENODE_ARCHIVE_DIRECTORY}/renode" ]] ||
+        die "Renode archive did not contain the expected executable"
+    [[ -x "${extract_parent}/${RENODE_ARCHIVE_DIRECTORY}/renode-test" ]] ||
+        die "Renode archive did not contain renode-test"
+    [[ -f "${extract_parent}/${RENODE_ARCHIVE_DIRECTORY}/licenses/renode-license" ]] ||
+        die "Renode archive did not contain its license"
+    mv -- "${extract_parent}/${RENODE_ARCHIVE_DIRECTORY}" "${renode_dir}"
+    rmdir -- "${extract_parent}"
+    {
+        printf 'archive=%s\n' "${RENODE_ARCHIVE}"
+        printf 'archive_sha256=%s\n' "${RENODE_SHA256}"
+        printf 'archive_size=%s\n' "${RENODE_SIZE}"
+    } > "${renode_dir}/.aymos-install-source"
+    write_tree_manifest "${renode_dir}"
+}
+
+install_python() {
+    local archive_path="${downloads_dir}/${PYTHON_ARCHIVE}"
+    local extract_parent
+    local actual_version
+
+    prepare_locked_download "CPython ${PYTHON_VERSION}" "${PYTHON_URL}" \
+        "${PYTHON_SHA256}" "${PYTHON_SIZE}" "${archive_path}"
+
+    if [[ -x "${python_dir}/bin/python3" ]]; then
+        validate_tree_manifest "${python_dir}" "CPython"
+        actual_version="$("${locked_python_env[@]}" \
+            "${python_dir}/bin/python3" \
+            -c 'import platform; print(platform.python_version())')"
+        [[ "${actual_version}" == "${PYTHON_VERSION}" ]] ||
+            die "installed Python is ${actual_version}, expected ${PYTHON_VERSION}"
+        note "CPython ${PYTHON_VERSION} already installed"
+        return
+    fi
+
+    [[ ! -e "${python_dir}" ]] ||
+        die "incomplete Python directory exists: ${python_dir}"
+    extract_parent="${tools_dir}/.extract-${PYTHON_DIRECTORY}-$$"
+    temporary_paths+=("${extract_parent}")
+    mkdir -p -- "${extract_parent}"
+    note "extracting CPython ${PYTHON_VERSION}"
+    tar -xzf "${archive_path}" -C "${extract_parent}"
+    [[ -x "${extract_parent}/python/bin/python3" ]] ||
+        die "Python archive did not contain the expected interpreter"
+    [[ -f "${extract_parent}/python/lib/python3.12/LICENSE.txt" ]] ||
+        die "Python archive did not contain its license"
+    mv -- "${extract_parent}/python" "${python_dir}"
+    rmdir -- "${extract_parent}"
+    {
+        printf 'archive=%s\n' "${PYTHON_ARCHIVE}"
+        printf 'archive_sha256=%s\n' "${PYTHON_SHA256}"
+        printf 'archive_size=%s\n' "${PYTHON_SIZE}"
+    } > "${python_dir}/.aymos-install-source"
+    write_tree_manifest "${python_dir}"
+}
+
+install_python_wheels() {
+    local count="${#RENODE_PYTHON_WHEEL_NAMES[@]}"
+    local index
+
+    ((count == ${#RENODE_PYTHON_WHEEL_URLS[@]} &&
+       count == ${#RENODE_PYTHON_WHEEL_SHA256S[@]} &&
+       count == ${#RENODE_PYTHON_WHEEL_SIZES[@]})) ||
+        die "Python wheel lock arrays have different lengths"
+    mkdir -p -- "${wheels_dir}"
+    for ((index = 0; index < count; index++)); do
+        prepare_locked_download \
+            "Python wheel ${RENODE_PYTHON_WHEEL_NAMES[index]}" \
+            "${RENODE_PYTHON_WHEEL_URLS[index]}" \
+            "${RENODE_PYTHON_WHEEL_SHA256S[index]}" \
+            "${RENODE_PYTHON_WHEEL_SIZES[index]}" \
+            "${wheels_dir}/${RENODE_PYTHON_WHEEL_NAMES[index]}"
+    done
+}
+
+validate_python_environment() {
+    local actual_version
+    local resolved_python
+
+    [[ -x "${python_venv_dir}/bin/python3" ]] ||
+        die "project Python virtual environment is incomplete"
+    validate_tree_manifest "${python_venv_dir}" "Python virtual environment"
+    resolved_python="$(readlink -f "${python_venv_dir}/bin/python3")"
+    [[ "${resolved_python}" == "$(readlink -f "${python_dir}/bin/python3")" ]] ||
+        die "virtual environment does not use the locked Python interpreter"
+    actual_version="$("${locked_python_env[@]}" \
+        "${python_venv_dir}/bin/python3" -c \
+        'import platform; print(platform.python_version())')"
+    [[ "${actual_version}" == "${PYTHON_VERSION}" ]] ||
+        die "virtual environment uses Python ${actual_version}, expected ${PYTHON_VERSION}"
+    "${locked_python_env[@]}" "${python_venv_dir}/bin/python3" -c \
+        'from importlib.metadata import version
+import psutil, RetryFailed, robot, telnetlib3, yaml
+assert robot.__version__ == "6.1"
+assert psutil.__version__ == "5.9.8"
+assert yaml.__version__ == "6.0.3"
+assert telnetlib3.__version__ == "2.0.8"
+assert version("robotframework-retryfailed") == "0.2.0"' ||
+        die "locked Renode Python packages failed their import/version check"
+}
+
+install_python_environment() {
+    if [[ -d "${python_venv_dir}" ]]; then
+        validate_python_environment
+        note "Renode Python environment already installed"
+        return
+    fi
+
+    [[ ! -e "${python_venv_dir}" ]] ||
+        die "non-directory Python environment path exists: ${python_venv_dir}"
+    note "creating the Renode Python environment"
+    python_venv_owned=true
+    "${locked_python_env[@]}" "${python_dir}/bin/python3" -m venv \
+        "${python_venv_dir}"
+    "${locked_python_env[@]}" PIP_DISABLE_PIP_VERSION_CHECK=1 \
+        "${python_venv_dir}/bin/python3" -m pip install \
+        --no-index --only-binary=:all: --require-hashes \
+        --find-links "${wheels_dir}" --requirement "${python_requirements}"
+    {
+        printf 'python_archive_sha256=%s\n' "${PYTHON_SHA256}"
+        printf 'requirements_sha256=%s\n' "$(sha256_file "${python_requirements}")"
+    } > "${python_venv_dir}/.aymos-install-source"
+    write_tree_manifest "${python_venv_dir}"
+    validate_python_environment
+    python_venv_owned=false
 }
 
 validate_git_dependency() {
@@ -317,6 +588,10 @@ install_cube_cmsis_core() {
 validate_installation() {
     local compiler="${toolchain_dir}/bin/arm-none-eabi-gcc"
     local gcc_version
+    local actual_version
+    local count
+    local index
+    local renode_version
 
     [[ -x "${compiler}" ]] || die "compiler installation is incomplete"
     validate_toolchain_marker
@@ -378,23 +653,66 @@ validate_installation() {
             die "build-consumed STM32 HAL file is missing: ${consumed}"
     done
 
-    note "validated Arm GCC ${gcc_version} and all locked STM32 dependencies"
+    [[ -x "${renode_dir}/renode" && -x "${renode_dir}/renode-test" ]] ||
+        die "Renode installation is incomplete"
+    validate_tree_manifest "${renode_dir}" "Renode"
+    grep -Fxq "archive=${RENODE_ARCHIVE}" "${renode_dir}/.aymos-install-source" ||
+        die "Renode source manifest archive mismatch"
+    grep -Fxq "archive_sha256=${RENODE_SHA256}" \
+        "${renode_dir}/.aymos-install-source" ||
+        die "Renode source manifest checksum mismatch"
+    renode_version="$(renode_version_output "${renode_dir}/renode")" ||
+        die "installed Renode version command failed or timed out"
+    [[ "${renode_version}" == *"Renode v${RENODE_VERSION}."* ]] ||
+        die "unexpected Renode version output"
+
+    [[ -x "${python_dir}/bin/python3" ]] ||
+        die "locked Python installation is incomplete"
+    validate_tree_manifest "${python_dir}" "CPython"
+    grep -Fxq "archive=${PYTHON_ARCHIVE}" "${python_dir}/.aymos-install-source" ||
+        die "Python source manifest archive mismatch"
+    grep -Fxq "archive_sha256=${PYTHON_SHA256}" \
+        "${python_dir}/.aymos-install-source" ||
+        die "Python source manifest checksum mismatch"
+    actual_version="$("${locked_python_env[@]}" \
+        "${python_dir}/bin/python3" \
+        -c 'import platform; print(platform.python_version())')"
+    [[ "${actual_version}" == "${PYTHON_VERSION}" ]] ||
+        die "installed Python is ${actual_version}, expected ${PYTHON_VERSION}"
+
+    count="${#RENODE_PYTHON_WHEEL_NAMES[@]}"
+    for ((index = 0; index < count; index++)); do
+        archive_matches "${wheels_dir}/${RENODE_PYTHON_WHEEL_NAMES[index]}" \
+            "${RENODE_PYTHON_WHEEL_SHA256S[index]}" \
+            "${RENODE_PYTHON_WHEEL_SIZES[index]}" ||
+            die "locked Python wheel is missing or modified: ${RENODE_PYTHON_WHEEL_NAMES[index]}"
+    done
+    validate_python_environment
+
+    note "validated Arm GCC ${gcc_version}, STM32 dependencies, Renode ${RENODE_VERSION}, and Python ${PYTHON_VERSION}"
 }
 
 check_host() {
-    [[ "$(uname -s)" == Linux ]] || die "PR 1 setup currently supports Linux only"
-    [[ "$(uname -m)" == x86_64 ]] || die "PR 1 setup currently supports Linux x86_64 only"
+    [[ "$(uname -s)" == Linux ]] || die "setup currently supports Linux only"
+    [[ "$(uname -m)" == x86_64 ]] || die "setup currently supports Linux x86_64 only"
 
     require_command awk
     require_command curl
+    require_command cmp
+    require_command env
     require_command file
+    require_command find
     require_command grep
     require_command git
     require_command make
     require_command od
+    require_command readlink
     require_command sha256sum
+    require_command sort
     require_command stat
     require_command tar
+    require_command timeout
+    require_command xargs
     require_command xz
 
     local git_version
@@ -444,6 +762,10 @@ main() {
     install_cube_cmsis_core
     install_git_dependency cmsis_device_f4 "${STM32_DEVICE_URL}" "${STM32_DEVICE_COMMIT}"
     install_git_dependency stm32f4xx_hal_driver "${STM32_HAL_URL}" "${STM32_HAL_COMMIT}"
+    install_renode
+    install_python
+    install_python_wheels
+    install_python_environment
     validate_installation
 }
 

--- a/tools/setup/dependencies.lock
+++ b/tools/setup/dependencies.lock
@@ -26,3 +26,57 @@ STM32_HAL_URL="https://github.com/STMicroelectronics/stm32f4xx_hal_driver.git"
 STM32_HAL_COMMIT="b6f0ed3829f3829eb358a2e7417d80bba1a42db7"
 STM32_DEVICE_URL="https://github.com/STMicroelectronics/cmsis_device_f4.git"
 STM32_DEVICE_COMMIT="3c77349ce04c8af401454cc51f85ea9a50e34fc1"
+
+# Renode's portable .NET release includes its runtime and models.  Robot tests
+# use the separately locked Python environment below; no system Renode or
+# Python packages are accepted by the setup/check paths.
+RENODE_VERSION="1.16.1"
+RENODE_ARCHIVE="renode-1.16.1.linux-portable-dotnet.tar.gz"
+RENODE_URL="https://github.com/renode/renode/releases/download/v1.16.1/${RENODE_ARCHIVE}"
+RENODE_SHA256="00e113cdbd0f5354cf2f64bbe3f5a070d8958409542fca66e45ac97d982938c0"
+RENODE_SIZE="77304986"
+RENODE_ARCHIVE_DIRECTORY="renode_1.16.1-dotnet_portable"
+RENODE_DIRECTORY="renode-1.16.1-dotnet-x86_64"
+
+PYTHON_VERSION="3.12.13"
+PYTHON_RELEASE="20260718"
+PYTHON_ARCHIVE="cpython-3.12.13+20260718-x86_64-unknown-linux-gnu-install_only.tar.gz"
+PYTHON_URL="https://github.com/astral-sh/python-build-standalone/releases/download/${PYTHON_RELEASE}/cpython-3.12.13%2B20260718-x86_64-unknown-linux-gnu-install_only.tar.gz"
+PYTHON_SHA256="7eea0959fa425c8aff3ea0a1352ee7d01d794b51439ed8f5fcfa017dbc0ec661"
+PYTHON_SIZE="111280988"
+PYTHON_DIRECTORY="python-3.12.13-20260718-x86_64"
+PYTHON_VENV_DIRECTORY="python-venv-renode-1.16.1"
+
+# These wheels are the complete, transitive runtime set needed by
+# renode-test for AymOS's Robot/UART tests. Renode upstream names psutil 5.9.3;
+# AymOS intentionally substitutes locally tested 5.9.8 because 5.9.3 has no
+# CPython 3.12 wheel and would introduce an undeclared host compiler input.
+# This substitution is not claimed to satisfy an exact ==5.9.3 constraint.
+RENODE_PYTHON_WHEEL_NAMES=(
+    "robotframework-6.1-py3-none-any.whl"
+    "robotframework_retryfailed-0.2.0-py3-none-any.whl"
+    "psutil-5.9.8-cp36-abi3-manylinux_2_12_x86_64.manylinux2010_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+    "pyyaml-6.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
+    "telnetlib3-2.0.8-py2.py3-none-any.whl"
+)
+RENODE_PYTHON_WHEEL_URLS=(
+    "https://files.pythonhosted.org/packages/11/ff/3105ff09e62c980e67a5b6974c8ac9577b4c3bacbc10a90e6b3e40cfcbd1/robotframework-6.1-py3-none-any.whl"
+    "https://files.pythonhosted.org/packages/24/80/144bca38aa894ec876f7943d3fd62fa57d9be937cc0be9e5d7e3df9837e3/robotframework_retryfailed-0.2.0-py3-none-any.whl"
+    "https://files.pythonhosted.org/packages/c5/4f/0e22aaa246f96d6ac87fe5ebb9c5a693fbe8877f537a1022527c47ca43c5/psutil-5.9.8-cp36-abi3-manylinux_2_12_x86_64.manylinux2010_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+    "https://files.pythonhosted.org/packages/8b/9d/b3589d3877982d4f2329302ef98a8026e7f4443c765c46cfecc8858c6b4b/pyyaml-6.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
+    "https://files.pythonhosted.org/packages/bf/ba/3bc29b36aed7ed157d73ad8afb18b96c29199bfda53a418b828867e1fc70/telnetlib3-2.0.8-py2.py3-none-any.whl"
+)
+RENODE_PYTHON_WHEEL_SHA256S=(
+    "46b04648547eab6433ce107c4b40757aa8bea1e47bd86af9c0cff5546dac767e"
+    "b389dadb446a4d7356d7e953aabfdf2b0497d51df11d3da80abe9d4a8a0992c3"
+    "d06016f7f8625a1825ba3732081d77c94589dca78b7a3fc072194851e88461a4"
+    "ba1cc08a7ccde2d2ec775841541641e4548226580ab850948cbfda66a1befcdc"
+    "9c5b762d359581af61b7872c5abd1aa82d8fd49044d12b4eb5a7c88660901dbd"
+)
+RENODE_PYTHON_WHEEL_SIZES=(
+    "698535"
+    "8638"
+    "288191"
+    "807870"
+    "109725"
+)

--- a/tools/setup/renode-requirements.lock
+++ b/tools/setup/renode-requirements.lock
@@ -1,0 +1,13 @@
+# Installed only from tools/setup/dependencies.lock's checksum-verified wheel
+# cache.  Keep every transitive dependency exact so --require-hashes can prove
+# the environment without consulting an index.
+robotframework==6.1 \
+    --hash=sha256:46b04648547eab6433ce107c4b40757aa8bea1e47bd86af9c0cff5546dac767e
+robotframework-retryfailed==0.2.0 \
+    --hash=sha256:b389dadb446a4d7356d7e953aabfdf2b0497d51df11d3da80abe9d4a8a0992c3
+psutil==5.9.8 \
+    --hash=sha256:d06016f7f8625a1825ba3732081d77c94589dca78b7a3fc072194851e88461a4
+PyYAML==6.0.3 \
+    --hash=sha256:ba1cc08a7ccde2d2ec775841541641e4548226580ab850948cbfda66a1befcdc
+telnetlib3==2.0.8 \
+    --hash=sha256:9c5b762d359581af61b7872c5abd1aa82d8fd49044d12b4eb5a7c88660901dbd


### PR DESCRIPTION
## Problem being solved

PR 1 produces a validated STM32F401RE ELF, but a developer still cannot prove that exact board-targeted image boots without physical hardware. This PR adds a pinned, headless Renode path and an automated UART contract.

## Scope

- Pin and verify a project-local Renode 1.16.1 installation and a hash-locked Python/Robot environment.
- Model the minimum NUCLEO-F401RE peripherals needed for boot and USART2 output.
- Add a headless run harness, a Robot emulator test, offline execution, diagnostics, and CI wiring.
- Add a minimal application smoke path for reset, SysTick, SVC, and UART.
- Update verified-vs-planned documentation.

This does **not** implement the AymOS task scheduler, PendSV/PSP switching, scheduler traces, or timing claims; those remain gated on later PRs.

## Important design decisions

- The PR is stacked on PR 1 because Renode boots its exact generated ELF.
- Renode is pinned to v1.16.1 with an expected archive URL, byte count, and SHA-256.
- CPython 3.12.13 and every Robot dependency are also pinned and hash-checked.
- The local platform description contains no remote SVD or runtime URL.
- Flash is mapped through one memory object at both the reset alias and canonical 0x08000000 range.
- UART validation is byte-oriented and requires exactly:
  - `AYMOS READY\r\n`
  - `AYMOS SMOKE SYSTICK=1 SVC=1\r\n`
- SysTick and SVC handlers only update observable flags; formatted UART is never performed inside them.
- Emulator runs use bounded host and virtual time. Metadata explicitly says the run is a functional test and makes no hardware timing claim.
- User `PYTHONHOME`, `PYTHONPATH`, and user site-packages are excluded from all pinned-Python entry points.
- Dependency integrity includes regular files and symlink targets; special nodes are rejected.

## Files and modules changed

- `platform/renode/`: F401RE platform description and launch script.
- `tools/renode/`: bounded run, Robot, offline, UART validation, and platform checks.
- `tests/renode/`: Robot boot contract plus native harness tests.
- `tools/setup.sh`, `tools/toolchain.lock`, `tools/renode-requirements.lock`: pinned local dependencies.
- `apps/boot/main.c`, BSP board/interrupt files: boot banner and SVC/SysTick smoke proof.
- `.github/workflows/ci.yml`: build/native/emulator CI definition.
- `Makefile`, README, status/dependency/implementation-plan docs.

## Exact test commands and results

Run from commit `b47f6cbc52bbb686d9cfd555104a45a606a4d220`:

```bash
make setup
make firmware
make test
make run
make test-emulator
make test-emulator-offline
```

Results:

- Setup integrity: PASS (Arm GNU 14.3.1, Cube dependencies, Renode 1.16.1, CPython 3.12.13).
- ELF/vector/memory-map validation: PASS.
- Native harness tests: 7/7 PASS.
- Headless run: PASS, exact 42-byte UART stream; SHA-256 `92df05c777d119f0cdcc2d382d7a7b60b1cfe7c35c3c9bfe0478fb4ea8c1edbc`.
- Robot emulator boot test: PASS.
- Network-isolated Robot emulator test: PASS.
- Ten-repeat emulator stress run performed during review: 10/10 PASS.
- Committed-state firmware SHA-256: `b5f1d2fab62b56284853849d325c36417229ee2544a3ae349d6a47e2f6444f07`.
- Committed-state platform SHA-256: `4ff56a9df476518f7e0ef7dce186bdd27da9ddfac26f15e31ca69a5c2ce2d98c`.
- Captured metadata reports `repository_clean=true` and the full commit SHA.
- Hosted GitHub Actions `F401RE build and Renode boot`: PASS in 57 seconds ([run 30721900895](https://github.com/sabdulmajid/aymos/actions/runs/30721900895)).

Review also exercised hostile environment isolation, changed/added symlink detection, special-node rejection, forced host timeout, zero virtual-duration failure, and process cleanup. All behaved as intended.

## Manual demonstration

```bash
make setup
make firmware
make run
make test-emulator
```

`make run` prints the two UART lines and preserves `command.txt`, `emulator.log`, raw/decoded UART, validation output, and metadata under `build/renode/run/<run-id>/`.

## Known limitations

- Hosted CI has passed for this commit; future dependency/base changes will require it to be rerun.
- Physical NUCLEO-F401RE flashing and UART have not been validated.
- The minimal Renode model emits retained diagnostics for currently unmodeled flash-cache/RCC bits.
- Renode proves functional behavior only; it does not establish interrupt latency, WCET, or hard real-time guarantees.
- The dependency manifest detects accidental corruption; it is not a security boundary against an attacker able to modify the verification scripts.

## Non-goals

- Scheduler or task-lifecycle integration.
- PendSV/PSP context switching.
- Host scheduler simulation.
- Physical-timing or hard-real-time claims.
- A full STM32F4 peripheral model.

## Dependency and branch relationship

- Base: `agent/pr1-reproducible-f401re-build`
- Head: `agent/pr2-renode-boot`
- Depends on draft PR #9.
- Intended merge order: PR 1, then this PR. Do not merge this PR first.

## Independent adversarial review

Reviewer: PR 2 adversarial reviewer (separate from the implementer).

Findings resolved before publication:

- Hardened dependency manifests for symlinks and special nodes.
- Isolated all locked Python paths from host `PYTHONHOME`/`PYTHONPATH`.
- Added complete run metadata and corrected the plan's unmerged dependency status.
- Added the missing `timeout` setup prerequisite.
- Replaced ambiguous SysTick counter language with the actual observable-flag contract.
- Corrected the documented Renode Python compatibility substitution.

Final reviewer judgment: **APPROVE**. Residual limitations are listed above.

## Lead judgment

**Ready for the maintainer's final review**, as a draft and subject to the required stacked merge order.